### PR TITLE
Rearrange tab stops for better keyboard navigation

### DIFF
--- a/BambooTracker/gui/configuration_dialog.ui
+++ b/BambooTracker/gui/configuration_dialog.ui
@@ -216,6 +216,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>generalSettingsListWidget</tabstop>
+  <tabstop>pageJumpLengthSpinBox</tabstop>
+  <tabstop>soundDeviceComboBox</tabstop>
+  <tabstop>sampleRateComboBox</tabstop>
+  <tabstop>bufferLengthHorizontalSlider</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/BambooTracker/gui/groove_settings_dialog.ui
+++ b/BambooTracker/gui/groove_settings_dialog.ui
@@ -61,6 +61,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>listWidget</tabstop>
+  <tabstop>addButton</tabstop>
+  <tabstop>removeButton</tabstop>
+  <tabstop>lineEdit</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/BambooTracker/gui/instrument_editor/instrument_editor_fm_form.ui
+++ b/BambooTracker/gui/instrument_editor/instrument_editor_fm_form.ui
@@ -577,6 +577,33 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>envNumSpinBox</tabstop>
+  <tabstop>envUsersLineEdit</tabstop>
+  <tabstop>alGraphicsView</tabstop>
+  <tabstop>lfoGroupBox</tabstop>
+  <tabstop>lfoNumSpinBox</tabstop>
+  <tabstop>lfoUsersLineEdit</tabstop>
+  <tabstop>amOp1CheckBox</tabstop>
+  <tabstop>amOp2CheckBox</tabstop>
+  <tabstop>amOp3CheckBox</tabstop>
+  <tabstop>amOp4CheckBox</tabstop>
+  <tabstop>lfoStartSpinBox</tabstop>
+  <tabstop>envResetCheckBox</tabstop>
+  <tabstop>opSeqTypeComboBox</tabstop>
+  <tabstop>opSeqEditGroupBox</tabstop>
+  <tabstop>opSeqNumSpinBox</tabstop>
+  <tabstop>opSeqUsersLineEdit</tabstop>
+  <tabstop>arpEditGroupBox</tabstop>
+  <tabstop>arpNumSpinBox</tabstop>
+  <tabstop>arpUsersLineEdit</tabstop>
+  <tabstop>arpTypeComboBox</tabstop>
+  <tabstop>ptEditGroupBox</tabstop>
+  <tabstop>ptNumSpinBox</tabstop>
+  <tabstop>ptUsersLineEdit</tabstop>
+  <tabstop>ptTypeComboBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/BambooTracker/gui/instrument_editor/instrument_editor_ssg_form.ui
+++ b/BambooTracker/gui/instrument_editor/instrument_editor_ssg_form.ui
@@ -403,6 +403,28 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>waveEditGroupBox</tabstop>
+  <tabstop>waveNumSpinBox</tabstop>
+  <tabstop>waveUsersLineEdit</tabstop>
+  <tabstop>squareMaskComboBox</tabstop>
+  <tabstop>tnEditGroupBox</tabstop>
+  <tabstop>tnNumSpinBox</tabstop>
+  <tabstop>tnUsersLineEdit</tabstop>
+  <tabstop>envEditGroupBox</tabstop>
+  <tabstop>envNumSpinBox</tabstop>
+  <tabstop>envUsersLineEdit</tabstop>
+  <tabstop>hardFreqSpinBox</tabstop>
+  <tabstop>arpEditGroupBox</tabstop>
+  <tabstop>arpNumSpinBox</tabstop>
+  <tabstop>arpUsersLineEdit</tabstop>
+  <tabstop>arpTypeComboBox</tabstop>
+  <tabstop>ptEditGroupBox</tabstop>
+  <tabstop>ptNumSpinBox</tabstop>
+  <tabstop>ptUsersLineEdit</tabstop>
+  <tabstop>ptTypeComboBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/BambooTracker/gui/mainwindow.ui
+++ b/BambooTracker/gui/mainwindow.ui
@@ -1152,6 +1152,24 @@
    <header>gui/line_read_only_spin_box.hpp</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>modTitleLineEdit</tabstop>
+  <tabstop>authorLineEdit</tabstop>
+  <tabstop>copyrightLineEdit</tabstop>
+  <tabstop>tickFreqSpinBox</tabstop>
+  <tabstop>modSetDialogOpenToolButton</tabstop>
+  <tabstop>stepHighrightSpinBox</tabstop>
+  <tabstop>octaveSpinBox</tabstop>
+  <tabstop>songNumSpinBox</tabstop>
+  <tabstop>songTitleLineEdit</tabstop>
+  <tabstop>songStyleLineEdit</tabstop>
+  <tabstop>tempoSpinBox</tabstop>
+  <tabstop>speedSpinBox</tabstop>
+  <tabstop>patternSizeSpinBox</tabstop>
+  <tabstop>grooveCheckBox</tabstop>
+  <tabstop>grooveSpinBox</tabstop>
+  <tabstop>instrumentListWidget</tabstop>
+ </tabstops>
  <resources>
   <include location="../bamboo_tracker.qrc"/>
  </resources>

--- a/BambooTracker/gui/module_properties_dialog.ui
+++ b/BambooTracker/gui/module_properties_dialog.ui
@@ -182,6 +182,16 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>songTreeWidget</tabstop>
+  <tabstop>upToolButton</tabstop>
+  <tabstop>downToolButton</tabstop>
+  <tabstop>removePushButton</tabstop>
+  <tabstop>editTitleLineEdit</tabstop>
+  <tabstop>insertTitleLineEdit</tabstop>
+  <tabstop>insertTypeComboBox</tabstop>
+  <tabstop>insertPushButton</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/BambooTracker/gui/vgm_export_settings_dialog.ui
+++ b/BambooTracker/gui/vgm_export_settings_dialog.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" rowstretch="2,4,4,0">
+  <layout class="QGridLayout" name="gridLayout" rowstretch="2,4,4">
    <item row="2" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
@@ -32,7 +32,7 @@
      <property name="checkable">
       <bool>true</bool>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2" rowstretch="1,0,0,0" columnstretch="2,0">
+     <layout class="QGridLayout" name="gridLayout_2" rowstretch="1,0,0" columnstretch="2,0">
       <property name="leftMargin">
        <number>6</number>
       </property>
@@ -349,6 +349,20 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>gd3GroupBox</tabstop>
+  <tabstop>titleEnLineEdit</tabstop>
+  <tabstop>titleJpLineEdit</tabstop>
+  <tabstop>authorEnLineEdit</tabstop>
+  <tabstop>authorJpLineEdit</tabstop>
+  <tabstop>nameEnLineEdit</tabstop>
+  <tabstop>nameJpLineEdit</tabstop>
+  <tabstop>systemEnLineEdit</tabstop>
+  <tabstop>systemJpLineEdit</tabstop>
+  <tabstop>releaseDateLineEdit</tabstop>
+  <tabstop>creatorLineEdit</tabstop>
+  <tabstop>notesPlainTextEdit</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Still though I can't seem to rearrange the tab order of those custom widgets that are generated later. Even setTabOrder() isn't working. So the tab stops for FM parameter sliders are still out of place.