### PR TITLE
README.md: Add README_jp.md content, Update Ubuntu version & Add Linux banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ It is able to reverse the order of FM volume (Configuration -> General -> Revers
 | Mxyy   | Volume delay (x[1-f]: count, yy[00-ff]: volume)                                         | Volume delay       | Volume delay                      |
 
 ## Build on Linux
-On Ubuntu 18.04:
+On Ubuntu 18.10: (18.04. is lacking the minimum currently required version of Qt: Qt 5.10)
 
 ### Dependencies
 > make  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # BambooTracker
 [![GitHub release](https://img.shields.io/badge/release-v0.1.3-orange.svg)](https://github.com/rerrahkr/BambooTracker/releases)
 ![Platform: win-32](https://img.shields.io/badge/platform-win--32-lightgrey.svg)
+![Platform: linux](https://img.shields.io/badge/platform-linux-lightgrey.svg)
 [![GitHub issues](https://img.shields.io/github/issues/rerrahkr/BambooTracker.svg)](https://github.com/rerrahkr/BambooTracker/issues)
 [![GitHub](https://img.shields.io/github/license/rerrahkr/BambooTracker.svg)](./LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,95 @@
 
 BambooTracker is a tracker for YM2608 (OPNA) which was used in NEC PC-8801/9801 series computers.
 
+## Glossary
+The files created by this tracker are called "modules". One such module contains songs (song data), instruments (tone data) and settings common to each song.
+In a song, the channel of each sound source is assigned to a track, and the track holds multiple patterns (performance patterns).
+The patterns are played by registering them in the order they appear the song. (from beginning to end)
+A pattern describes a structure in which steps are arranged in chronological order. Key On / off and most effects are described in step units.
+A tick ​​is the minimum performance unit, one step = n ticks. The effects (such as vibrato) which change with the count unit are based on ticks.
+
+## Interface Overview
+### Instrument List
+In the Instrument List, you control the instruments (tone data) used in the module. All songs in the module share the instruments registered here. Up to 128 instruments can be registered (`$00` - `$7F`).
+
+### Instrument Editor
+Double-clicking an instrument opens the Instrument Editor and allows you to edit said instrument.
+Instruments can share their settings (properties) with other instruments. For instruments that share properties, a list of all users (instruments) of each property are displayed.
+
+Some instrument editors can set performance sequences. One column corresponds to one tick in the sequence editor.
+It also corresponds to specifying the sequence loop / release point. Left click to create point or increase count / type change, right click to delete point or decrease count. You can move the position by dragging the edge of the point.
+For the release type, you can select from the following three types only for envelope setting of SSG.
+
+- Fix: Run at specified volume from release point at Key Off
+- Absolute: Run from the first point after the release point to reach the volume at Key Off
+- Relative: Execute from the release point with the volume set as the maximum volume at Key Off
+
+#### FM Editor
+In the FM Editor, you can configure the
+
+1. Envelope
+2. LFO
+3. Operator Sequence
+4. Arpeggio
+5. Pitch
+
+of an FM instrument.
+
+#### SSG Editor
+In the SSG Editor, you can configure the
+
+1. Waveform
+2. Tone / noise
+3. Envelope
+4. Arpeggio
+5. Pitch
+
+of an SSG instrument.
+The software envelope will be invalid while using waveforms other than rectangular waves.
+
+### Order List
+In the Order List, we will register the pattern numbers in the order in which they will be played. The rows correspond to the order, and the columns correspond to tracks.
+The maximum length of the list is 256 (`$FF`).
+
+### Pattern Editor
+In the pattern Editor, events such as Key On are registered in chronological order. One line represents one step. The columns of each track, from left to right, are:
+
+1.  Notes
+2.  Instrument numbers
+3.  Volume
+4.  Two characters before effect 1
+5.  Two characters after effect 1
+6.  Two characters before effect 2
+7.  Two characters after effect 2
+8.  Two characters before effect 3
+9.  Two characters after effect 3
+10. Two characters before effect 4
+11. Two characters after effect 4
+
+Effects 2-3 can be displayed and hidden by pressing the + and - buttons on the header.
+Up to 256 patterns (`$00` - `$FF`) can be created for each track.
+
+### Settings Field
+In the Settings Field you can adjust the module's metadata and performance settings of the song.
+
+#### Tick Frequency
+Sets the frequency of the tick. NTSC is 60 Hz, PAL is 50 Hz.
+
+#### Tempo
+Specify the tempo of the song. The tempo here is different from bpm, it is simply an indicator of speed.
+It can also be specified with the `0Fxx` effect.
+
+#### Speed
+Set the number of ticks for rough estimate in 1 step. Tempo may cause this value to change at run time.
+It can also be specified with the `0Fxx` effect.
+
+#### Pattern Size
+Sets the number of steps in the default pattern. The minimum value is 1, the maximum value is 256.
+
+#### Groove
+Specify the groove number set in the Groove Editor. When using groove, all other performance speed settings are fixed. 
+It can also be specified with `0Oxx` effect.
+
 ## Key commands
 ### General
 | Key    | Command                        |

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ It is able to reverse the order of FM volume (Configuration -> General -> Revers
 | Mxyy   | Volume delay (x[1-f]: count, yy[00-ff]: volume)                                         | Volume delay       | Volume delay                      |
 
 ## Build on Linux
-On Ubuntu 18.10: (18.04. is lacking the minimum currently required version of Qt: Qt 5.10)
+On Ubuntu 18.10: (18.04 is lacking the minimum currently required version of Qt: Qt 5.10)
 
 ### Dependencies
 > make  

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,6 +1,7 @@
 # BambooTracker
 [![GitHub release](https://img.shields.io/badge/release-v0.1.3-orange.svg)](https://github.com/rerrahkr/BambooTracker/releases)
 ![Platform: win-32](https://img.shields.io/badge/platform-win--32-lightgrey.svg)
+![Platform: linux](https://img.shields.io/badge/platform-linux-lightgrey.svg)
 [![GitHub issues](https://img.shields.io/github/issues/rerrahkr/BambooTracker.svg)](https://github.com/rerrahkr/BambooTracker/issues)
 [![GitHub](https://img.shields.io/github/license/rerrahkr/BambooTracker.svg)](./LICENSE)
 


### PR DESCRIPTION
This PR will:

1) add some roughly translated (Google Translator) and slightly manually refined chunks from `README_jp.md` to `README.md`.
  I figured it'd be useful to have, since it describes some basic concepts and usage of BambooTracker. I assume it wasn't translated from the get-go because it wasn't essential and *alot* to translate?

2) specify the new minimum version of Ubuntu (18.10) required for building while we're working on getting it compatible with the LTS version again ( see https://github.com/rerrahkr/BambooTracker/issues/28 )

3) add this platform: linux badge to both READMEs, akin to the existing platform: win-32 one
  ![Platform: linux](https://img.shields.io/badge/platform-linux-lightgrey.svg)
---
In case 2) will become obsolete before merging, I'll push a revert of 2) or start a new PR with just the translation.
Same applies if the badge isn't desired because it's "not officially supported, but working nonetheless". :slightly_smiling_face: 