### PR TITLE
Support importing instruments from banks in WOPN format

### DIFF
--- a/BambooTracker/BambooTracker.pro
+++ b/BambooTracker/BambooTracker.pro
@@ -162,7 +162,9 @@ SOURCES += \
     gui/command/pattern/paste_overwrite_copied_data_to_pattern_qt_command.cpp \
     command/pattern/paste_overwrite_copied_data_to_pattern_command.cpp \
     io/file_io_error.cpp \
-    format/wopn_file.c
+    format/wopn_file.c \
+    instrument/bank.cpp \
+    gui/instrument_selection_dialog.cpp
 
 HEADERS += \
     gui/mainwindow.hpp \
@@ -316,7 +318,9 @@ HEADERS += \
     gui/command/pattern/paste_overwrite_copied_data_to_pattern_qt_command.hpp \
     command/pattern/paste_overwrite_copied_data_to_pattern_command.hpp \
     io/file_io_error.hpp \
-    format/wopn_file.h
+    format/wopn_file.h \
+    instrument/bank.hpp \
+    gui/instrument_selection_dialog.hpp
 
 FORMS += \
     gui/mainwindow.ui \
@@ -333,7 +337,8 @@ FORMS += \
     gui/configuration_dialog.ui \
     gui/comment_edit_dialog.ui \
     gui/vgm_export_settings_dialog.ui \
-    gui/wave_export_settings_dialog.ui
+    gui/wave_export_settings_dialog.ui \
+    gui/instrument_selection_dialog.ui
 
 INCLUDEPATH += \
     $$PWD/chips \

--- a/BambooTracker/BambooTracker.pro
+++ b/BambooTracker/BambooTracker.pro
@@ -164,7 +164,7 @@ SOURCES += \
     io/file_io_error.cpp \
     format/wopn_file.c \
     instrument/bank.cpp \
-    gui/instrument_selection_dialog.cpp
+    gui/instrument_selection_dialog.cpp \
     gui/s98_export_settings_dialog.cpp
 
 HEADERS += \
@@ -321,7 +321,7 @@ HEADERS += \
     io/file_io_error.hpp \
     format/wopn_file.h \
     instrument/bank.hpp \
-    gui/instrument_selection_dialog.hpp
+    gui/instrument_selection_dialog.hpp \
     io/s98_tag.hpp \
     gui/s98_export_settings_dialog.hpp
 
@@ -341,7 +341,7 @@ FORMS += \
     gui/comment_edit_dialog.ui \
     gui/vgm_export_settings_dialog.ui \
     gui/wave_export_settings_dialog.ui \
-    gui/instrument_selection_dialog.ui
+    gui/instrument_selection_dialog.ui \
     gui/s98_export_settings_dialog.ui
 
 INCLUDEPATH += \

--- a/BambooTracker/bamboo_tracker.cpp
+++ b/BambooTracker/bamboo_tracker.cpp
@@ -5,6 +5,7 @@
 #include <exception>
 #include "commands.hpp"
 #include "file_io.hpp"
+#include "bank.hpp"
 
 const uint32_t BambooTracker::CHIP_CLOCK = 3993600 * 2;
 
@@ -111,6 +112,13 @@ void BambooTracker::loadInstrument(std::string path, int instNum)
 void BambooTracker::saveInstrument(std::string path, int instNum)
 {
 	FileIO::saveInstrument(path, instMan_, instNum);
+}
+
+void BambooTracker::importInstrument(const AbstractBank &bank, size_t index, int instNum)
+{
+	auto inst = bank.loadInstrument(index, instMan_, instNum);
+	comMan_.invoke(std::make_unique<AddInstrumentCommand>(
+					   instMan_, std::unique_ptr<AbstractInstrument>(inst)));
 }
 
 int BambooTracker::findFirstFreeInstrumentNumber() const

--- a/BambooTracker/bamboo_tracker.hpp
+++ b/BambooTracker/bamboo_tracker.hpp
@@ -17,6 +17,8 @@
 #include "gd3_tag.hpp"
 #include "misc.hpp"
 
+class AbstractBank;
+
 class BambooTracker
 {
 public:
@@ -45,6 +47,7 @@ public:
 	void deepCloneInstrument(int num, int refNum);
 	void loadInstrument(std::string path, int instNum);
 	void saveInstrument(std::string path, int instNum);
+	void importInstrument(const AbstractBank &bank, size_t index, int instNum);
 	int findFirstFreeInstrumentNumber() const;
 	void setInstrumentName(int num, std::string name);
 	void clearAllInstrument();

--- a/BambooTracker/gui/instrument_selection_dialog.cpp
+++ b/BambooTracker/gui/instrument_selection_dialog.cpp
@@ -1,0 +1,45 @@
+#include "instrument_selection_dialog.hpp"
+#include "ui_instrument_selection_dialog.h"
+#include "bank.hpp"
+
+InstrumentSelectionDialog::InstrumentSelectionDialog(const AbstractBank &bank, const QString &text, QWidget *parent)
+	: QDialog(parent), bank_(bank), ui_(new Ui::InstrumentSelectionDialog) {
+	ui_->setupUi(this);
+	ui_->label->setText(text);
+	setupContents();
+}
+
+InstrumentSelectionDialog::~InstrumentSelectionDialog() {
+}
+
+void InstrumentSelectionDialog::setupContents()
+{
+	QListWidget *lw = ui_->listWidget;
+	lw->setSelectionMode(QListWidget::MultiSelection);
+
+	size_t instCount = bank_.getNumInstruments();
+	for (size_t i = 0; i < instCount; ++i) {
+		QString id = QString::fromStdString(bank_.getInstrumentIdentifier(i));
+		QString name = QString::fromStdString(bank_.getInstrumentName(i));
+
+		QListWidgetItem *item = new QListWidgetItem(QString("%1 %2").arg(id).arg(name));
+		item->setData(Qt::UserRole, (qulonglong)i);
+		lw->addItem(item);
+	}
+}
+
+QVector<size_t> InstrumentSelectionDialog::currentInstrumentSelection() const
+{
+	QListWidget *lw = ui_->listWidget;
+	QList<QListWidgetItem *> items = lw->selectedItems();
+
+	QVector<size_t> selection;
+	selection.reserve(items.size());
+
+	for (QListWidgetItem *item : items) {
+		size_t index = (size_t)item->data(Qt::UserRole).toULongLong();
+		selection.push_back(index);
+	}
+
+	return selection;
+}

--- a/BambooTracker/gui/instrument_selection_dialog.hpp
+++ b/BambooTracker/gui/instrument_selection_dialog.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QDialog>
+#include <QVector>
+#include <memory>
+
+class AbstractBank;
+
+namespace Ui {
+	class InstrumentSelectionDialog;
+};
+
+class InstrumentSelectionDialog : public QDialog
+{
+public:
+	InstrumentSelectionDialog(const AbstractBank &bank, const QString &text, QWidget *parent = nullptr);
+	~InstrumentSelectionDialog();
+
+	QVector<size_t> currentInstrumentSelection() const;
+
+private:
+	const AbstractBank &bank_;
+	std::unique_ptr<Ui::InstrumentSelectionDialog> ui_;
+
+	void setupContents();
+};

--- a/BambooTracker/gui/instrument_selection_dialog.ui
+++ b/BambooTracker/gui/instrument_selection_dialog.ui
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>InstrumentSelectionDialog</class>
+ <widget class="QDialog" name="InstrumentSelectionDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Select instruments</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListWidget" name="listWidget"/>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>InstrumentSelectionDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>InstrumentSelectionDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/BambooTracker/gui/mainwindow.cpp
+++ b/BambooTracker/gui/mainwindow.cpp
@@ -19,6 +19,8 @@
 #include "song.hpp"
 #include "track.hpp"
 #include "instrument.hpp"
+#include "bank.hpp"
+#include "file_io.hpp"
 #include "version.hpp"
 #include "gui/command/commands_qt.hpp"
 #include "gui/instrument_editor/instrument_editor_fm_form.hpp"
@@ -29,6 +31,7 @@
 #include "gui/comment_edit_dialog.hpp"
 #include "gui/wave_export_settings_dialog.hpp"
 #include "gui/vgm_export_settings_dialog.hpp"
+#include "gui/instrument_selection_dialog.hpp"
 #include "gui/configuration_handler.hpp"
 
 MainWindow::MainWindow(QWidget *parent) :
@@ -726,6 +729,51 @@ void MainWindow::saveInstrument()
 		bt_->saveInstrument(file.toLocal8Bit().toStdString(),
 							ui->instrumentListWidget->currentItem()->data(Qt::UserRole).toInt());
 		config_->setWorkingDirectory(QFileInfo(file).dir().path().toStdString());
+	}
+	catch (std::exception& e) {
+		QMessageBox::critical(this, "Error", e.what());
+	}
+}
+
+void MainWindow::importInstrumentsFromBank()
+{
+	QString dir = QString::fromStdString(config_->getWorkingDirectory());
+	QString file = QFileDialog::getOpenFileName(this, "Open bank", (dir.isEmpty() ? "./" : dir),
+												"WOPN bank (*.wopn)");
+	if (file.isNull()) return;
+
+	std::unique_ptr<AbstractBank> bank;
+	try {
+		bank.reset(FileIO::loadBank(file.toLocal8Bit().toStdString()));
+		config_->setWorkingDirectory(QFileInfo(file).dir().path().toStdString());
+	}
+	catch (std::exception& e) {
+		QMessageBox::critical(this, "Error", e.what());
+		return;
+	}
+
+	InstrumentSelectionDialog dlg(*bank, tr("Select instruments to load:"), this);
+	if (dlg.exec() != QDialog::Accepted)
+		return;
+
+	QVector<size_t> selection = dlg.currentInstrumentSelection();
+
+	try {
+		for (size_t index : selection) {
+			int n = bt_->findFirstFreeInstrumentNumber();
+			if (n == -1){
+				QMessageBox::critical(this, "Error", "Failed to load instrument.");
+				return;
+			}
+
+			bt_->importInstrument(*bank, index, n);
+
+			auto inst = bt_->getInstrument(n);
+			auto name = inst->getName();
+			comStack_->push(new AddInstrumentQtCommand(ui->instrumentListWidget, n,
+													   QString::fromUtf8(name.c_str(), name.length()),
+													   inst->getSoundSource(), instForms_));
+		}
 	}
 	catch (std::exception& e) {
 		QMessageBox::critical(this, "Error", e.what());
@@ -1719,6 +1767,11 @@ void MainWindow::on_actionLoad_From_File_triggered()
 void MainWindow::on_actionSave_To_File_triggered()
 {
 	saveInstrument();
+}
+
+void MainWindow::on_actionImport_From_Bank_File_triggered()
+{
+	importInstrumentsFromBank();
 }
 
 void MainWindow::on_actionInterpolate_triggered()

--- a/BambooTracker/gui/mainwindow.hpp
+++ b/BambooTracker/gui/mainwindow.hpp
@@ -21,6 +21,8 @@
 #include "gui/instrument_editor/instrument_form_manager.hpp"
 #include "gui/color_palette.hpp"
 
+class AbstractBank;
+
 namespace Ui {
 	class MainWindow;
 }
@@ -63,6 +65,7 @@ private:
     void deepCloneInstrument();
 	void loadInstrument();
 	void saveInstrument();
+	void importInstrumentsFromBank();
 
 	// Undo-Redo
 	void undo();
@@ -161,6 +164,7 @@ private slots:
 	void on_actionOpen_triggered();
 	void on_actionLoad_From_File_triggered();
 	void on_actionSave_To_File_triggered();
+	void on_actionImport_From_Bank_File_triggered();
 	void on_actionInterpolate_triggered();
 	void on_actionReverse_triggered();
 	void on_actionReplace_Instrument_triggered();

--- a/BambooTracker/gui/mainwindow.ui
+++ b/BambooTracker/gui/mainwindow.ui
@@ -409,7 +409,7 @@
      <x>0</x>
      <y>0</y>
      <width>930</width>
-     <height>21</height>
+     <height>25</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -534,6 +534,8 @@
     <addaction name="separator"/>
     <addaction name="actionLoad_From_File"/>
     <addaction name="actionSave_To_File"/>
+    <addaction name="separator"/>
+    <addaction name="actionImport_From_Bank_File"/>
     <addaction name="separator"/>
     <addaction name="actionEdit"/>
    </widget>
@@ -1129,6 +1131,11 @@
   <action name="actionOverwrite">
    <property name="text">
     <string>&amp;Overwrite</string>
+   </property>
+  </action>
+  <action name="actionImport_From_Bank_File">
+   <property name="text">
+    <string>&amp;Import From Bank File...</string>
    </property>
   </action>
  </widget>

--- a/BambooTracker/instrument/bank.cpp
+++ b/BambooTracker/instrument/bank.cpp
@@ -1,0 +1,66 @@
+#include "bank.hpp"
+#include "file_io.hpp"
+#include "format/wopn_file.h"
+#include <stdio.h>
+
+void WopnBank::WOPNDeleter::operator()(WOPNFile *x) {
+	WOPN_Free(x);
+}
+
+struct WopnBank::InstEntry {
+	WOPNInstrument *inst;
+	struct {
+		bool percussive : 1;
+		unsigned msb : 7;
+		unsigned lsb : 7;
+		unsigned nth : 7;
+	};
+};
+
+WopnBank::WopnBank(WOPNFile *wopn) : wopn_(wopn) {
+	unsigned numM = wopn->banks_count_melodic;
+	unsigned numP = wopn->banks_count_percussion;
+
+	size_t instMax = 128 * (numP + numM);
+	entries_.reserve(instMax);
+
+	for (size_t i = 0; i < instMax; ++i) {
+		InstEntry ent;
+		ent.percussive = (i / 128) >= numM;
+		WOPNBank &bank = ent.percussive ?
+			wopn->banks_percussive[(i / 128) - numM] :
+			wopn->banks_melodic[i / 128];
+		ent.msb = bank.bank_midi_msb;
+		ent.lsb = bank.bank_midi_lsb;
+		ent.nth = i % 128;
+		ent.inst = &bank.ins[ent.nth];
+		if ((ent.inst->inst_flags & WOPN_Ins_IsBlank) == 0)
+			entries_.push_back(ent);
+	}
+
+	entries_.shrink_to_fit();
+}
+
+WopnBank::~WopnBank() {
+}
+
+size_t WopnBank::getNumInstruments() const {
+	return entries_.size();
+}
+
+std::string WopnBank::getInstrumentIdentifier(size_t index) const {
+	const InstEntry &ent = entries_.at(index);
+	char identifier[64];
+	sprintf(identifier, "%c%03d:%03d:%03d", "MP"[ent.percussive], ent.msb, ent.lsb, ent.nth);
+	return identifier;
+}
+
+std::string WopnBank::getInstrumentName(size_t index) const {
+	const InstEntry &ent = entries_.at(index);
+	return ent.inst->inst_name;
+}
+
+AbstractInstrument* WopnBank::loadInstrument(size_t index, std::weak_ptr<InstrumentsManager> instMan, int instNum) const {
+	const InstEntry &ent = entries_.at(index);
+	return FileIO::loadWOPNInstrument(*ent.inst, instMan, instNum);
+}

--- a/BambooTracker/instrument/bank.hpp
+++ b/BambooTracker/instrument/bank.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+class AbstractInstrument;
+class InstrumentsManager;
+struct WOPNFile;
+
+class AbstractBank
+{
+public:
+	virtual ~AbstractBank() = default;
+
+	virtual size_t getNumInstruments() const = 0;
+	virtual std::string getInstrumentIdentifier(size_t index) const = 0;
+	virtual std::string getInstrumentName(size_t index) const = 0;
+	virtual AbstractInstrument* loadInstrument(size_t index, std::weak_ptr<InstrumentsManager> instMan, int instNum) const = 0;
+};
+
+class WopnBank : public AbstractBank
+{
+public:
+	explicit WopnBank(WOPNFile *wopn);
+	~WopnBank();
+
+	size_t getNumInstruments() const override;
+	std::string getInstrumentIdentifier(size_t index) const override;
+	std::string getInstrumentName(size_t index) const override;
+	AbstractInstrument* loadInstrument(size_t index, std::weak_ptr<InstrumentsManager> instMan, int instNum) const override;
+
+private:
+	struct WOPNDeleter {
+		void operator()(WOPNFile *x);
+	};
+	std::unique_ptr<WOPNFile, WOPNDeleter> wopn_;
+
+	struct InstEntry;
+	std::vector<InstEntry> entries_;
+};

--- a/BambooTracker/io/file_io.hpp
+++ b/BambooTracker/io/file_io.hpp
@@ -8,6 +8,9 @@
 #include "binary_container.hpp"
 #include "gd3_tag.hpp"
 
+class AbstractBank;
+struct WOPNInstrument;
+
 class FileIO
 {
 public:
@@ -18,6 +21,7 @@ public:
 	static void saveInstrument(std::string path, std::weak_ptr<InstrumentsManager> instMan, int instNum);
 	static AbstractInstrument* loadInstrument(std::string path, std::weak_ptr<InstrumentsManager> instMan,
 											  int instNum);
+	static AbstractBank* loadBank(std::string path);
 	static void writeWave(std::string path, std::vector<int16_t> samples, uint32_t rate);
 
 	static void writeVgm(std::string path, std::vector<uint8_t> samples, uint32_t clock, uint32_t rate,
@@ -43,6 +47,14 @@ private:
 	static AbstractInstrument* loadOPNIFile(std::string path,
 										   std::weak_ptr<InstrumentsManager> instMan,
 										   int instNum);
+
+public:
+	static AbstractInstrument* loadWOPNInstrument(const WOPNInstrument &srcInst,
+										   std::weak_ptr<InstrumentsManager> instMan,
+										   int instNum);
+
+private:
+	static AbstractBank* loadWOPNFile(std::string path);
 	static size_t loadModuleSectionInModule(std::weak_ptr<Module> mod, BinaryContainer& ctr,
 											size_t globCsr, uint32_t version);
 	static size_t loadInstrumentSectionInModule(std::weak_ptr<InstrumentsManager> instMan,

--- a/BambooTracker/io/file_io_error.cpp
+++ b/BambooTracker/io/file_io_error.cpp
@@ -8,6 +8,7 @@ std::string FileIOError::fileTypeToString(const FileType type)
 	case FileType::INST:	return "instrument";
 	case FileType::WAV:		return "wav";
 	case FileType::VGM:		return "vgm";
+	case FileType::BANK:		return "bank";
 	}
 }
 

--- a/BambooTracker/io/file_io_error.hpp
+++ b/BambooTracker/io/file_io_error.hpp
@@ -9,7 +9,7 @@ class FileIOError
 public:
 	enum class FileType
 	{
-		MOD, INST, WAV, VGM
+		MOD, INST, WAV, VGM, BANK
 	};
 
 	static std::string fileTypeToString(const FileType type);


### PR DESCRIPTION
This follows WOPN instrument support, adding the support of bank files.
In the GUI, I added `Import From Bank File`, which permits to load a choice of instruments from a `.wopn` file.
To do this, I added a dialog and I introduced a model for banks which I thought to be appropriate.
The instruments are picked from a list widget and it's possible to load several of them at once.

EDIT: add minor fix where the error did not indicate the good file type