### PR TITLE
Fix invalid memory access on main window destruction

### DIFF
--- a/BambooTracker/gui/mainwindow.cpp
+++ b/BambooTracker/gui/mainwindow.cpp
@@ -332,7 +332,6 @@ MainWindow::MainWindow(QWidget *parent) :
 
 MainWindow::~MainWindow()
 {
-	delete ui;
 }
 
 bool MainWindow::eventFilter(QObject *watched, QEvent *event)

--- a/BambooTracker/gui/mainwindow.hpp
+++ b/BambooTracker/gui/mainwindow.hpp
@@ -44,8 +44,7 @@ protected:
 	void closeEvent(QCloseEvent* event) override;
 
 private:
-	Ui::MainWindow *ui;
-
+	std::unique_ptr<Ui::MainWindow> ui;
 	std::shared_ptr<Configuration> config_;
 	std::shared_ptr<ColorPalette> palette_;
 	std::shared_ptr<BambooTracker> bt_;


### PR DESCRIPTION
Solves bad access into freed memory when the program is closed, found by address sanitizer.
On destruction of the comstack, it triggers a slot on the main window whose `ui` has been freed prior.

To prevent the problem, I ensure to destroy the `ui` last.
I put the variable in RAII and it's working because the members destroy in reverse order.