### PR TITLE
Improve project description for unfamiliar readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub issues](https://img.shields.io/github/issues/rerrahkr/BambooTracker.svg)](https://github.com/rerrahkr/BambooTracker/issues)
 [![GitHub](https://img.shields.io/github/license/rerrahkr/BambooTracker.svg)](./LICENSE)
 
-BambooTracker is a tracker for YM2608 (OPNA) which was used in NEC PC-8801/9801 series computers.
+BambooTracker is a music tracker for the Yamaha YM2608 (OPNA) sound chip which was used in NEC PC-8801/9801 series computers.
 
 ## Glossary
 The files created by this tracker are called "modules". One such module contains songs (song data), instruments (tone data) and settings common to each song.


### PR DESCRIPTION
Give some more context in the project description, to help readers
unfamiliar with the project domain understand what the project is
actually about, specifically:

1. remove ambiguity about the word "tracker", make it clear that this is
   a "music tracker";

2. mention that the YM2608 is a sound chip from Yamaha, to save readers
   from a web search to find out this information.