### PR TITLE
Add define to skip words on linux

### DIFF
--- a/BambooTracker/chips/scci/scci.h
+++ b/BambooTracker/chips/scci/scci.h
@@ -7,6 +7,9 @@
 using DWORD = uint32_t;
 using BOOL = bool;
 using BYTE = uint8_t;
+#ifndef WIN32
+#define __stdcall
+#endif
 
 // Sound Interface Infomation
 typedef struct {


### PR DESCRIPTION
fix #46, but I don't have linux.
@papiezak, would you mind checking it on linux?