### PR TITLE
Add instructions for FreeBSD users

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,21 @@ qmake
 make
 ```
 
+## Install package or build on FreeBSD
+
+### Build
+To build the BambooTracker via FreeBSD ports
+```bash
+cd /usr/ports/audio/bambootracker
+make install clean
+```
+
+### Package
+To install the package
+```bash
+pkg install bambootracker
+```
+
 ## Changelog
 *See [CHANGELOG.md](./CHANGELOG.md).*
 


### PR DESCRIPTION
Now that there is an official [FreeBSD port](https://svnweb.freebsd.org/ports/head/audio/bambootracker/) for bambootracker. Add some instructions.