### PR TITLE
Add installation rules and loader for translations

### DIFF
--- a/BambooTracker/BambooTracker.pro
+++ b/BambooTracker/BambooTracker.pro
@@ -5,6 +5,7 @@
 #-------------------------------------------------
 
 QT       += core gui multimedia
+CONFIG   += lrelease
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
@@ -21,6 +22,22 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # In order to do so, uncomment the following line.
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+
+# This produces the installation rule for the program and resources.
+# Use a default destination prefix if none is given.
+isEmpty(PREFIX) {
+    win32:PREFIX = C:/BambooTracker
+    else:PREFIX = /usr/local
+}
+INSTALLS += target
+win32 {
+    QM_FILES_INSTALL_PATH = $$PREFIX/lang
+    target.path = $$PREFIX
+}
+else {
+    QM_FILES_INSTALL_PATH = $$PREFIX/share/BambooTracker/lang
+    target.path = $$PREFIX/bin
+}
 
 CONFIG += c++14
 
@@ -367,5 +384,8 @@ INCLUDEPATH += \
 
 RESOURCES += \
     bamboo_tracker.qrc
+
+TRANSLATIONS += \
+    res/lang/bamboo_tracker_fr.ts
 
 RC_ICONS = res/icon/BambooTracker.ico

--- a/BambooTracker/main.cpp
+++ b/BambooTracker/main.cpp
@@ -1,13 +1,23 @@
 #include "./gui/mainwindow.hpp"
 #include <QApplication>
 #include <QMessageBox>
+#include <QTranslator>
+#include <QLibraryInfo>
+#include <QDir>
 #include <QObject>
+#include <QDebug>
 #include <memory>
+
+// Localization
+static void setupTranslations();
+static QString findQtTranslationsDir();
+static QString findAppTranslationsDir();
 
 int main(int argc, char *argv[])
 {
 	try {
 		std::unique_ptr<QApplication> a(std::make_unique<QApplication>(argc, argv));
+		setupTranslations();
 		std::unique_ptr<MainWindow> w(std::make_unique<MainWindow>());
 		w->show();
 		return a->exec();
@@ -15,4 +25,76 @@ int main(int argc, char *argv[])
 		QMessageBox::critical(nullptr, QObject::tr("Error"), QObject::tr("An unknown error occured."));
 		return -1;
 	}
+}
+
+// Sets up the translation according to the current language
+static void setupTranslations()
+{
+	QApplication *a = qApp;
+	const QString lang = QLocale::system().name();
+
+	QTranslator *qtTr = new QTranslator(a);
+	QTranslator *appTr = new QTranslator(a);
+
+	QString qtDir = findQtTranslationsDir();
+	QString appDir = findAppTranslationsDir();
+
+	if (!qtDir.isEmpty()) {
+		QString baseName = "qt_" + lang;
+		qtTr->load(baseName, qtDir);
+		qDebug() << "Translation" << baseName << "from" << qtDir;
+	}
+
+	if (!appDir.isEmpty()) {
+		QString baseName = "bamboo_tracker_" + lang;
+		appTr->load(baseName, appDir);
+		qDebug() << "Translation" << baseName << "from" << appDir;
+	}
+
+	a->installTranslator(qtTr);
+	a->installTranslator(appTr);
+}
+
+// Finds the location of Qt translation catalogs
+static QString findQtTranslationsDir()
+{
+#if defined(Q_OS_DARWIN)
+	// if this is macOS, attempt to load from inside an app bundle
+	QString pathInAppBundle = QApplication::applicationDirPath() + "/../Resources/lang";
+	if (QDir(pathInAppBundle).exists())
+		return pathInAppBundle;
+#endif
+
+#if defined(Q_OS_WIN)
+	// if this is Windows, translations should be distributed with the program
+	return QApplication::applicationDirPath() + "/lang";
+#else
+	// the files are located in the installation of Qt
+	return QLibraryInfo::location(QLibraryInfo::TranslationsPath);
+#endif
+}
+
+// Finds the location of our translation catalogs
+static QString findAppTranslationsDir()
+{
+#ifndef QT_NO_DEBUG
+	// if this is a debug build, attempt to load from the source directory
+	QString pathInSources = QApplication::applicationDirPath() + "/.qm";
+	if (QDir(pathInSources).exists())
+		return pathInSources;
+#endif
+
+#if defined(Q_OS_DARWIN)
+	// if this is macOS, attempt to load from inside an app bundle
+	QString pathInAppBundle = QApplication::applicationDirPath() + "/../Resources/lang";
+	if (QDir(pathInAppBundle).exists())
+		return pathInAppBundle;
+#endif
+
+#if defined(Q_OS_WIN)
+	// if this is Windows, translations should be distributed with the program
+	return QApplication::applicationDirPath() + "/lang";
+#else
+	return QApplication::applicationDirPath() + "/../share/BambooTracker/lang";
+#endif
 }

--- a/BambooTracker/res/lang/bamboo_tracker_fr.ts
+++ b/BambooTracker/res/lang/bamboo_tracker_fr.ts
@@ -1,0 +1,1926 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr_FR">
+<context>
+    <name>CommentEditDialog</name>
+    <message>
+        <location filename="../../gui/comment_edit_dialog.ui" line="14"/>
+        <source>Module Comment</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ConfigurationDialog</name>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="14"/>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="34"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="40"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="46"/>
+        <source>Key off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="56"/>
+        <source>Octave up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="66"/>
+        <source>Octave down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="76"/>
+        <source>Echo buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="89"/>
+        <source>Edit settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="95"/>
+        <source>Page jump length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="131"/>
+        <source>General settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="138"/>
+        <source>Warp cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="146"/>
+        <source>Warp across orders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="154"/>
+        <source>Show row numbers in hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="162"/>
+        <source>Preview previous/next orders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="170"/>
+        <source>Backup modules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="178"/>
+        <source>Don&apos;t select on double click</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="186"/>
+        <source>Reverse FM volume order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="194"/>
+        <source>Move cursor to right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="211"/>
+        <source>Description:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="222"/>
+        <source>Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="228"/>
+        <source>Sample rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="253"/>
+        <source>Buffer length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="272"/>
+        <source>1ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="282"/>
+        <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="291"/>
+        <source>Use SCCI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="302"/>
+        <source>Mixer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="308"/>
+        <source>Part</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.ui" line="336"/>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.cpp" line="77"/>
+        <source>Master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.cpp" line="150"/>
+        <source>Warp the cursor around the edges of the pattern editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.cpp" line="153"/>
+        <source>Move to previous or next order when reaching top or bottom in the pattern editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.cpp" line="156"/>
+        <source>Display order numbers and the order count on the status bar in hexadecimal.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.cpp" line="159"/>
+        <source>Preview previous and next orders in the pattern editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.cpp" line="162"/>
+        <source>Create a backup copy of the existing file when saving a module.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.cpp" line="165"/>
+        <source>Don&apos;t select the whole track when double-clicking in the pattern editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.cpp" line="168"/>
+        <source>Reverse the order of FM volume so that 00 is the quietest in the pattern editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.cpp" line="171"/>
+        <source>Move the cursor to right after entering effects in the pattern editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/configuration_dialog.cpp" line="177"/>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FMOperatorTable</name>
+    <message>
+        <location filename="../../gui/instrument_editor/fm_operator_table.ui" line="14"/>
+        <source>Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/fm_operator_table.ui" line="37"/>
+        <source>Operator </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/fm_operator_table.ui" line="131"/>
+        <source>SSGEG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/fm_operator_table.cpp" line="47"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/fm_operator_table.cpp" line="318"/>
+        <source>Copy envelope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/fm_operator_table.cpp" line="320"/>
+        <source>Paste envelope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/fm_operator_table.cpp" line="323"/>
+        <source>Copy operator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/fm_operator_table.cpp" line="325"/>
+        <source>Paste operator</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GrooveSettingsDialog</name>
+    <message>
+        <location filename="../../gui/groove_settings_dialog.ui" line="14"/>
+        <source>Groove Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/groove_settings_dialog.ui" line="42"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/groove_settings_dialog.ui" line="58"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>InstrumentEditorFMForm</name>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="27"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="33"/>
+        <source>Envelope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="65"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="167"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="385"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="450"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="518"/>
+        <source>#</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="75"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="177"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="395"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="460"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="528"/>
+        <source>Users:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="149"/>
+        <source>LFO/Operator sequence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="155"/>
+        <source>LFO</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="196"/>
+        <source>Start count:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="219"/>
+        <source>AM operators</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="225"/>
+        <source>Operator 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="232"/>
+        <source>Operator 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="239"/>
+        <source>Operator 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="246"/>
+        <source>Operator 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="293"/>
+        <source>Reset envelope before key on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="318"/>
+        <source>Operator sequence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="324"/>
+        <source>Operator:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="347"/>
+        <source>Sequence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="409"/>
+        <source>Arpeggio/Pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="415"/>
+        <source>Arpeggio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="470"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="538"/>
+        <source>Type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.ui" line="483"/>
+        <source>Pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.cpp" line="401"/>
+        <source>Absolute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.cpp" line="402"/>
+        <source>Fix</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.cpp" line="403"/>
+        <source>Relative</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.cpp" line="1144"/>
+        <source>Copy envelope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.cpp" line="1146"/>
+        <source>Paste envelope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.cpp" line="1266"/>
+        <source>Copy LFO parameters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_fm_form.cpp" line="1268"/>
+        <source>Paste LFO parameters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>InstrumentEditorSSGForm</name>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="24"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="30"/>
+        <source>Wave form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="65"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="137"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="205"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="287"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="362"/>
+        <source>#</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="75"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="117"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="185"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="297"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="372"/>
+        <source>Users:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="85"/>
+        <source>Square mask:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="99"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="105"/>
+        <source>Tone/Noise</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="164"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="170"/>
+        <source>Envelope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="215"/>
+        <source>Hard frequency:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="246"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="252"/>
+        <source>Arpeggio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="307"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="382"/>
+        <source>Type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="321"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.ui" line="327"/>
+        <source>Pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.cpp" line="223"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.cpp" line="288"/>
+        <source>Absolute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.cpp" line="224"/>
+        <source>Fix</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.cpp" line="225"/>
+        <location filename="../../gui/instrument_editor/instrument_editor_ssg_form.cpp" line="289"/>
+        <source>Relative</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>InstrumentSelectionDialog</name>
+    <message>
+        <location filename="../../gui/instrument_selection_dialog.ui" line="14"/>
+        <source>Select instruments</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LabeledHorizontalSlider</name>
+    <message>
+        <location filename="../../gui/labeled_horizontal_slider.ui" line="14"/>
+        <source>Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/labeled_horizontal_slider.ui" line="40"/>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/labeled_horizontal_slider.ui" line="54"/>
+        <source>0</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LabeledVerticalSlider</name>
+    <message>
+        <location filename="../../gui/labeled_vertical_slider.ui" line="14"/>
+        <source>Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/labeled_vertical_slider.ui" line="40"/>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/labeled_vertical_slider.ui" line="54"/>
+        <source>0</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="17"/>
+        <source>BambooTracker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="53"/>
+        <source>Order List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="82"/>
+        <source>Module Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="103"/>
+        <source>Hz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="119"/>
+        <source>...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="126"/>
+        <source>Tick Freq</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="133"/>
+        <source>Copyright</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="140"/>
+        <source>Author</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="147"/>
+        <source>Module Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="157"/>
+        <source>Edit settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="163"/>
+        <source>Editable step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="190"/>
+        <source>Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="197"/>
+        <location filename="../../gui/mainwindow.ui" line="338"/>
+        <source>#</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="217"/>
+        <source>Song Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="238"/>
+        <source>Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="245"/>
+        <source>Pattern Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="252"/>
+        <source>Tempo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="285"/>
+        <source>Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="311"/>
+        <location filename="../../gui/mainwindow.cpp" line="548"/>
+        <location filename="../../gui/mainwindow.cpp" line="605"/>
+        <location filename="../../gui/mainwindow.cpp" line="1035"/>
+        <location filename="../../gui/mainwindow.cpp" line="1037"/>
+        <location filename="../../gui/mainwindow.cpp" line="1688"/>
+        <location filename="../../gui/mainwindow.cpp" line="1797"/>
+        <source>Untitled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="328"/>
+        <source>Groove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="353"/>
+        <source>Instruments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="406"/>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="410"/>
+        <source>&amp;Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="430"/>
+        <source>&amp;Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="434"/>
+        <source>&amp;Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="447"/>
+        <source>Paste Specia&amp;l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="466"/>
+        <location filename="../../gui/mainwindow.ui" line="1106"/>
+        <source>&amp;Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="470"/>
+        <source>&amp;Transpose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="488"/>
+        <source>&amp;Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="501"/>
+        <source>&amp;Module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="505"/>
+        <source>Clean&amp;up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="519"/>
+        <source>&amp;Instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="535"/>
+        <source>T&amp;racker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="553"/>
+        <source>&amp;Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="601"/>
+        <source>toolBar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="619"/>
+        <source>&amp;New...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="622"/>
+        <source>Ctrl+N</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="634"/>
+        <source>&amp;Open...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="637"/>
+        <source>Ctrl+O</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="649"/>
+        <source>&amp;Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="652"/>
+        <source>Ctrl+S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="660"/>
+        <source>Save &amp;As...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="665"/>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="677"/>
+        <source>&amp;Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="680"/>
+        <source>Ctrl+Z</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="692"/>
+        <source>&amp;Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="695"/>
+        <source>Ctrl+Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="704"/>
+        <source>Cu&amp;t</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="707"/>
+        <source>Ctrl+X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="716"/>
+        <source>&amp;Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="719"/>
+        <source>Ctrl+C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="728"/>
+        <source>&amp;Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="731"/>
+        <source>Ctrl+V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="736"/>
+        <source>&amp;Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="739"/>
+        <source>Del</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="744"/>
+        <source>&amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="747"/>
+        <source>Ctrl+A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="752"/>
+        <source>&amp;None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="755"/>
+        <source>Esc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="763"/>
+        <source>E&amp;xpand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="771"/>
+        <source>S&amp;hrink</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="776"/>
+        <source>&amp;Decrease Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="779"/>
+        <source>Ctrl+F1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="784"/>
+        <source>&amp;Increase Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="787"/>
+        <source>Ctrl+F2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="792"/>
+        <source>D&amp;ecrease Octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="795"/>
+        <source>Ctrl+F3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="800"/>
+        <source>I&amp;ncrease Octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="803"/>
+        <source>Ctrl+F4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="808"/>
+        <source>&amp;Insert Order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="813"/>
+        <source>&amp;Remove Order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="822"/>
+        <source>&amp;Module Properties...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="825"/>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="834"/>
+        <source>&amp;New Instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="846"/>
+        <source>&amp;Remove Instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="858"/>
+        <source>&amp;Clone Instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="866"/>
+        <source>&amp;Deep Clone Instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="878"/>
+        <source>&amp;Load From File...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="890"/>
+        <source>&amp;Save To File...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="902"/>
+        <location filename="../../gui/mainwindow.cpp" line="1077"/>
+        <source>&amp;Edit...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="905"/>
+        <source>Ctrl+I</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="914"/>
+        <source>&amp;Play</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="923"/>
+        <source>Play P&amp;attern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="926"/>
+        <source>F6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="931"/>
+        <source>Play &amp;From Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="934"/>
+        <source>F5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="939"/>
+        <source>Play From C&amp;ursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="942"/>
+        <source>F7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="951"/>
+        <source>&amp;Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="954"/>
+        <source>F8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="962"/>
+        <source>&amp;Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="965"/>
+        <source>Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="970"/>
+        <source>To&amp;ggle Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="973"/>
+        <source>Alt+F9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="978"/>
+        <source>S&amp;olo Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="981"/>
+        <source>Alt+F10</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="986"/>
+        <source>&amp;Kill Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="989"/>
+        <source>F12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="994"/>
+        <source>&amp;About...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1005"/>
+        <source>Fo&amp;llow Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1008"/>
+        <source>ScrollLock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1013"/>
+        <source>&amp;Groove Settings...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1022"/>
+        <source>&amp;Configuration...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1027"/>
+        <source>&amp;Duplicate Order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1030"/>
+        <source>Ctrl+D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1035"/>
+        <source>Move Order &amp;Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1040"/>
+        <source>Move Order Do&amp;wn</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1045"/>
+        <source>&amp;Clone Patterns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1048"/>
+        <source>Alt+D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1053"/>
+        <source>Clone &amp;Order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1058"/>
+        <source>&amp;Comments...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1066"/>
+        <source>&amp;Interpolate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1069"/>
+        <source>Ctrl+G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1077"/>
+        <source>&amp;Reverse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1080"/>
+        <source>Ctrl+R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1088"/>
+        <source>R&amp;eplace Instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1091"/>
+        <source>Alt+S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1096"/>
+        <source>&amp;Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1101"/>
+        <source>&amp;Column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1111"/>
+        <source>&amp;Order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1116"/>
+        <source>Remove Unused &amp;Instruments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1121"/>
+        <source>Remove Unused &amp;Patterns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1126"/>
+        <source>&amp;WAV...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1131"/>
+        <source>&amp;VGM...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1136"/>
+        <source>&amp;Mix</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1139"/>
+        <source>Ctrl+M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1144"/>
+        <source>&amp;Overwrite</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1149"/>
+        <source>&amp;Import From Bank File...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.ui" line="1154"/>
+        <source>&amp;S98...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="133"/>
+        <source>Octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="147"/>
+        <source>Step highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="368"/>
+        <location filename="../../gui/mainwindow.cpp" line="982"/>
+        <source>Octave: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="551"/>
+        <location filename="../../gui/mainwindow.cpp" line="608"/>
+        <location filename="../../gui/mainwindow.cpp" line="1691"/>
+        <location filename="../../gui/mainwindow.cpp" line="1800"/>
+        <source>Save changes to %1?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="576"/>
+        <location filename="../../gui/mainwindow.cpp" line="752"/>
+        <location filename="../../gui/mainwindow.cpp" line="764"/>
+        <location filename="../../gui/mainwindow.cpp" line="782"/>
+        <location filename="../../gui/mainwindow.cpp" line="799"/>
+        <location filename="../../gui/mainwindow.cpp" line="813"/>
+        <location filename="../../gui/mainwindow.cpp" line="827"/>
+        <location filename="../../gui/mainwindow.cpp" line="1733"/>
+        <location filename="../../gui/mainwindow.cpp" line="1747"/>
+        <location filename="../../gui/mainwindow.cpp" line="1770"/>
+        <location filename="../../gui/mainwindow.cpp" line="1787"/>
+        <location filename="../../gui/mainwindow.cpp" line="1831"/>
+        <location filename="../../gui/mainwindow.cpp" line="1962"/>
+        <location filename="../../gui/mainwindow.cpp" line="2008"/>
+        <location filename="../../gui/mainwindow.cpp" line="2054"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="652"/>
+        <source>Instrument %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="743"/>
+        <source>Open instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="752"/>
+        <location filename="../../gui/mainwindow.cpp" line="813"/>
+        <source>Failed to load instrument.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="771"/>
+        <source>Save instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="789"/>
+        <source>Open bank</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="803"/>
+        <source>Select instruments to load:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="867"/>
+        <location filename="../../gui/mainwindow.cpp" line="1240"/>
+        <source>No instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="870"/>
+        <location filename="../../gui/mainwindow.cpp" line="906"/>
+        <source>Standard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="871"/>
+        <location filename="../../gui/mainwindow.cpp" line="907"/>
+        <source>FM3ch expanded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1057"/>
+        <source>&amp;Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1059"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1064"/>
+        <source>Edit &amp;name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1067"/>
+        <source>&amp;Clone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1069"/>
+        <source>&amp;Deep clone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1072"/>
+        <source>&amp;Load from file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1074"/>
+        <source>&amp;Save to file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1242"/>
+        <source>Instrument: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1501"/>
+        <source>Do you want to change song properties?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1590"/>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1733"/>
+        <location filename="../../gui/mainwindow.cpp" line="1770"/>
+        <source>Failed to backup module.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1759"/>
+        <source>Save module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1816"/>
+        <source>Open module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1891"/>
+        <source>Do you want to remove all unused instruments?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1913"/>
+        <source>Do you want to remove all unused patterns?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1931"/>
+        <source>Export to wav</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1937"/>
+        <source>Export to WAV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1938"/>
+        <location filename="../../gui/mainwindow.cpp" line="1982"/>
+        <location filename="../../gui/mainwindow.cpp" line="2028"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1962"/>
+        <source>Failed to export to wav file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1975"/>
+        <source>Export to vgm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="1981"/>
+        <source>Export to VGM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="2008"/>
+        <source>Failed to export to vgm file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="2021"/>
+        <source>Export to s98</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="2027"/>
+        <source>Export to S98</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/mainwindow.cpp" line="2054"/>
+        <source>Failed to export to s98 file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ModulePropertiesDialog</name>
+    <message>
+        <location filename="../../gui/module_properties_dialog.ui" line="14"/>
+        <source>Module properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/module_properties_dialog.ui" line="20"/>
+        <source>Song control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/module_properties_dialog.ui" line="29"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/module_properties_dialog.ui" line="58"/>
+        <location filename="../../gui/module_properties_dialog.ui" line="153"/>
+        <source>...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/module_properties_dialog.ui" line="77"/>
+        <source>Insert song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/module_properties_dialog.ui" line="83"/>
+        <source>Title:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/module_properties_dialog.ui" line="90"/>
+        <source>Song type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/module_properties_dialog.ui" line="125"/>
+        <source>Insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/module_properties_dialog.ui" line="134"/>
+        <location filename="../../gui/module_properties_dialog.ui" line="166"/>
+        <source>Untitled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/module_properties_dialog.cpp" line="16"/>
+        <source>Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/module_properties_dialog.cpp" line="16"/>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/module_properties_dialog.cpp" line="16"/>
+        <source>Song type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/module_properties_dialog.cpp" line="24"/>
+        <location filename="../../gui/module_properties_dialog.cpp" line="40"/>
+        <source>Standard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/module_properties_dialog.cpp" line="41"/>
+        <source>FM3ch expanded</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OrderListEditor</name>
+    <message>
+        <location filename="../../gui/order_list_editor/order_list_editor.ui" line="14"/>
+        <source>Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OrderListPanel</name>
+    <message>
+        <location filename="../../gui/order_list_editor/order_list_panel.cpp" line="538"/>
+        <source>&amp;Insert Order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/order_list_editor/order_list_panel.cpp" line="540"/>
+        <source>&amp;Remove Order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/order_list_editor/order_list_panel.cpp" line="542"/>
+        <source>&amp;Duplicate Order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/order_list_editor/order_list_panel.cpp" line="544"/>
+        <source>&amp;Clone Patterns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/order_list_editor/order_list_panel.cpp" line="546"/>
+        <source>Clone &amp;Order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/order_list_editor/order_list_panel.cpp" line="549"/>
+        <source>Move Order &amp;Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/order_list_editor/order_list_panel.cpp" line="551"/>
+        <source>Move Order Do&amp;wn</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/order_list_editor/order_list_panel.cpp" line="554"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/order_list_editor/order_list_panel.cpp" line="556"/>
+        <source>&amp;Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PatternEditor</name>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor.ui" line="14"/>
+        <source>Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PatternEditorPanel</name>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1240"/>
+        <source>&amp;Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1245"/>
+        <source>&amp;Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1251"/>
+        <source>&amp;Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1253"/>
+        <source>Cu&amp;t</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1255"/>
+        <source>&amp;Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1257"/>
+        <source>Paste Specia&amp;l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1259"/>
+        <source>&amp;Mix</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1261"/>
+        <source>&amp;Overwrite</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1263"/>
+        <source>&amp;Erase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1265"/>
+        <source>Select &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1268"/>
+        <source>Patter&amp;n</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1270"/>
+        <source>&amp;Interpolate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1272"/>
+        <source>&amp;Reverse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1274"/>
+        <source>R&amp;eplace Instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1277"/>
+        <source>E&amp;xpand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1279"/>
+        <source>S&amp;hrink</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1282"/>
+        <source>&amp;Transpose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1284"/>
+        <source>&amp;Decrease Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1286"/>
+        <source>&amp;Increase Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1288"/>
+        <source>D&amp;ecrease Octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1290"/>
+        <source>I&amp;ncrease Octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1293"/>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="2081"/>
+        <source>To&amp;ggle Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="1295"/>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="2083"/>
+        <source>&amp;Solo Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/pattern_editor/pattern_editor_panel.cpp" line="2085"/>
+        <source>&amp;Unmute All Tracks</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../main.cpp" line="25"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../main.cpp" line="25"/>
+        <source>An unknown error occured.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>S98ExportSettingsDialog</name>
+    <message>
+        <location filename="../../gui/s98_export_settings_dialog.ui" line="14"/>
+        <source>S98 export settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/s98_export_settings_dialog.ui" line="20"/>
+        <source>Tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/s98_export_settings_dialog.ui" line="29"/>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/s98_export_settings_dialog.ui" line="39"/>
+        <source>Artist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/s98_export_settings_dialog.ui" line="49"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/s98_export_settings_dialog.ui" line="59"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/s98_export_settings_dialog.ui" line="69"/>
+        <source>Genre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/s98_export_settings_dialog.ui" line="79"/>
+        <source>Comment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/s98_export_settings_dialog.ui" line="89"/>
+        <source>Copyright</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/s98_export_settings_dialog.ui" line="99"/>
+        <source>S98by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/s98_export_settings_dialog.ui" line="109"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/s98_export_settings_dialog.ui" line="116"/>
+        <source>NEC PC-9801</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VgmExportSettingsDialog</name>
+    <message>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="14"/>
+        <source>VGM export settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="30"/>
+        <source>GD3 tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="54"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="81"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="88"/>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="175"/>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="216"/>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="255"/>
+        <source>English</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="113"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="133"/>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="165"/>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="223"/>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="262"/>
+        <source>Japanese</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="158"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="172"/>
+        <source>NEC PC-9801</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="185"/>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="209"/>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="248"/>
+        <source>Author</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="272"/>
+        <source>VGM file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="296"/>
+        <source>Creator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/vgm_export_settings_dialog.ui" line="337"/>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VisualizedInstrumentMacroEditor</name>
+    <message>
+        <location filename="../../gui/instrument_editor/visualized_instrument_macro_editor.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/visualized_instrument_macro_editor.ui" line="55"/>
+        <source>-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/visualized_instrument_macro_editor.ui" line="62"/>
+        <source>+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/visualized_instrument_macro_editor.ui" line="69"/>
+        <source>Size: 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/visualized_instrument_macro_editor.cpp" line="46"/>
+        <source>Release </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/visualized_instrument_macro_editor.cpp" line="153"/>
+        <location filename="../../gui/instrument_editor/visualized_instrument_macro_editor.cpp" line="185"/>
+        <source>Size: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/visualized_instrument_macro_editor.cpp" line="322"/>
+        <source>Loop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/visualized_instrument_macro_editor.cpp" line="332"/>
+        <source>Loop %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/visualized_instrument_macro_editor.cpp" line="352"/>
+        <source>Release</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/visualized_instrument_macro_editor.cpp" line="365"/>
+        <source>Fix</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/visualized_instrument_macro_editor.cpp" line="368"/>
+        <source>Absolute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/instrument_editor/visualized_instrument_macro_editor.cpp" line="371"/>
+        <source>Relative</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WaveExportSettingsDialog</name>
+    <message>
+        <location filename="../../gui/wave_export_settings_dialog.ui" line="14"/>
+        <source>WAV export settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/wave_export_settings_dialog.ui" line="20"/>
+        <source>Loop:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
#50 

I add the skeleton of a :fr: translation, and the logic to handle it.
With `qmake`, one can now pass the `PREFIX=...` argument to decide where the program installs.
This sets up the translations in an adequate relative path.

There is a strategy to search the right place for translations, which has to made according to preferences of each platform. When `qmake` is used for debugging (`CONFIG+=debug`), the translations will also be searched in the source directory for convenience.

notify @trebmuh

EDIT minor modifications to adapt the coding style