### PR TITLE
Fix translation building for <Qt5.12

### DIFF
--- a/BambooTracker/BambooTracker.pro
+++ b/BambooTracker/BambooTracker.pro
@@ -5,7 +5,6 @@
 #-------------------------------------------------
 
 QT       += core gui multimedia
-CONFIG   += lrelease
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
@@ -390,5 +389,47 @@ RESOURCES += \
 
 TRANSLATIONS += \
     res/lang/bamboo_tracker_fr.ts
+
+equals(QT_MAJOR_VERSION, 5) {
+    lessThan(QT_MINOR_VERSION, 12) {
+        message(using a workaround for missing 'lrelease' option in Qt <5.12...)
+        
+        for(tsfile, TRANSLATIONS) {
+          qmfile   = $$tsfile
+          qmfile  ~= s/.ts$/.qm/
+          qmfile  ~= s,^res/lang,.qm,
+          
+                  thisqmcom  = $${qmfile}.commands
+          win32:$$thisqmcom  = md .qm;
+           else:$$thisqmcom  = test -d .qm || mkdir -p .qm;
+                $$thisqmcom += lrelease -qm $$qmfile $$tsfile
+          
+            thisqmdep  = $${qmfile}.depends
+          $$thisqmdep  = $${tsfile}
+          
+          PRE_TARGETDEPS      += $${qmfile}
+          QMAKE_EXTRA_TARGETS += $${qmfile}
+          
+          
+            thisinst    = translations_$${qmfile}
+            thisinstdep = $${thisinst}.depends
+          $$thisinstdep = $$qmfile
+          
+            thisinstcfg = $${thisinst}.CONFIG
+          $$thisinstcfg = no_check_exist
+          
+            thisinstfil = $${thisinst}.files
+          $$thisinstfil = $$PWD/$$qmfile
+
+            thisinstpat = $${thisinst}.path
+          $$thisinstpat = $$QM_FILES_INSTALL_PATH
+          
+          INSTALLS += $$thisinst
+        }
+    }
+    else {
+        CONFIG += lrelease
+    }
+}
 
 RC_ICONS = res/icon/BambooTracker.ico


### PR DESCRIPTION
This fixes .ts files not being converted to .qm files and not being installed on <Qt5.12. (Ubuntu 18.04 LTS uses Qt5.9)

Feel free to improve on this code, but at least the translation files get automatically converted and installed on my Ubuntu machine now :)