### PR TITLE
Fix SSG Mixer settings not being loaded properly

### DIFF
--- a/BambooTracker/gui/configuration_handler.cpp
+++ b/BambooTracker/gui/configuration_handler.cpp
@@ -168,7 +168,7 @@ bool ConfigurationHandler::loadConfiguration(std::weak_ptr<Configuration> config
 		settings.beginGroup("Mixer");
 		configLocked->setMixerVolumeMaster(settings.value("mixerVolumeMaster", configLocked->getMixerVolumeMaster()).toInt());
 		configLocked->setMixerVolumeFM(settings.value("mixerVolumeFM", configLocked->getMixerVolumeFM()).toDouble());
-		configLocked->setMixerVolumeFM(settings.value("mixerVolumeSSG", configLocked->getMixerVolumeSSG()).toDouble());
+		configLocked->setMixerVolumeSSG(settings.value("mixerVolumeSSG", configLocked->getMixerVolumeSSG()).toDouble());
 		settings.endGroup();
 
 		// Input //


### PR DESCRIPTION
This also affected the FM Mixer settings when restarting the tracker.
Fixes https://github.com/rerrahkr/BambooTracker/issues/66