### PR TITLE
fix Out-of-Path build for Qt version workaround

### DIFF
--- a/BambooTracker/BambooTracker.pro
+++ b/BambooTracker/BambooTracker.pro
@@ -412,10 +412,10 @@ equals(QT_MAJOR_VERSION, 5) {
                   thisqmcom  = $${qmfile}.commands
           win32:$$thisqmcom  = mkdir .qm;
            else:$$thisqmcom  = test -d .qm || mkdir -p .qm;
-                $$thisqmcom += lrelease -qm $$qmfile $$tsfile
+                $$thisqmcom += lrelease -qm $$qmfile $$PWD/$$tsfile
 
             thisqmdep  = $${qmfile}.depends
-          $$thisqmdep  = $${tsfile}
+          $$thisqmdep  = $$PWD/$${tsfile}
           
           PRE_TARGETDEPS      += $${qmfile}
           QMAKE_EXTRA_TARGETS += $${qmfile}


### PR DESCRIPTION
( closes https://github.com/rerrahkr/BambooTracker/issues/83 )

By prefixing the .ts files with `$$PWD`, we will point to the absolute path of the files when building into another directory.