### PR TITLE
Indicate the correct version in specification documents

### DIFF
--- a/inst_specs.md
+++ b/inst_specs.md
@@ -1,5 +1,5 @@
 # BambooTracker Instrument File (.bti) Format Specification
-v1.0.1 - 2018-12-10
+v1.1.0 - 2019-03-24
 
 - All data are little endian.
 - Unless otherwise noted, character encoding of string is ASCII.

--- a/mod_specs.md
+++ b/mod_specs.md
@@ -1,5 +1,5 @@
 # BambooTracker Module File (.btm) Format Specification
- v1.0.3 - 2019-03-18
+ v1.1.0 - 2019-03-24
 
 - All data are little endian.
 - Unless otherwise noted, character encoding of string is ASCII.


### PR DESCRIPTION
It was forgotten to change the document versions after updating.