### PR TITLE
Fix MML format edit alignment

### DIFF
--- a/BambooTracker/gui/fm_envelope_set_edit_dialog.cpp
+++ b/BambooTracker/gui/fm_envelope_set_edit_dialog.cpp
@@ -54,6 +54,8 @@ void FMEnvelopeSetEditDialog::swapset(int aboveRow, int belowRow)
 		tree->setItemWidget(below, 1, belowBox);
 	}
 
+	if (!aboveRow || !belowRow) alignTreeOn1stItemChanged();	// Dummy set and delete to align
+
 	for (int i = aboveRow; i < ui->treeWidget->topLevelItemCount(); ++i) {
 		ui->treeWidget->topLevelItem(i)->setText(0, QString::number(i));
 	}
@@ -73,6 +75,8 @@ void FMEnvelopeSetEditDialog::insertRow(int row, FMEnvelopeTextType type)
 	}
 	ui->treeWidget->insertTopLevelItem(row, item);
 	ui->treeWidget->setItemWidget(item, 1, box);
+
+	if (!row) alignTreeOn1stItemChanged();	// Dummy set and delete to align
 
 	for (int i = row + 1; i < ui->treeWidget->topLevelItemCount(); ++i) {
 		ui->treeWidget->topLevelItem(i)->setText(0, QString::number(i));
@@ -124,6 +128,14 @@ QComboBox* FMEnvelopeSetEditDialog::makeCombobox()
 	return box;
 }
 
+/// Dummy set and delete to align
+void FMEnvelopeSetEditDialog::alignTreeOn1stItemChanged()
+{
+	auto tmp = new QTreeWidgetItem();
+	ui->treeWidget->insertTopLevelItem(1, tmp);
+	delete ui->treeWidget->takeTopLevelItem(1);
+}
+
 void FMEnvelopeSetEditDialog::on_upToolButton_clicked()
 {
 	int curRow = ui->treeWidget->currentIndex().row();
@@ -155,7 +167,12 @@ void FMEnvelopeSetEditDialog::on_addPushButton_clicked()
 
 void FMEnvelopeSetEditDialog::on_removePushButton_clicked()
 {
-	delete ui->treeWidget->takeTopLevelItem(ui->treeWidget->currentIndex().row());
+	int row = ui->treeWidget->currentIndex().row();
+	delete ui->treeWidget->takeTopLevelItem(row);
+
+	for (int i = row; i < ui->treeWidget->topLevelItemCount(); ++i) {
+		ui->treeWidget->topLevelItem(i)->setText(0, QString::number(i));
+	}
 
 	if (!ui->treeWidget->topLevelItemCount()) {
 		ui->upToolButton->setEnabled(false);

--- a/BambooTracker/gui/fm_envelope_set_edit_dialog.hpp
+++ b/BambooTracker/gui/fm_envelope_set_edit_dialog.hpp
@@ -32,6 +32,7 @@ private:
 	void swapset(int aboveRow, int belowRow);
 	void insertRow(int row, FMEnvelopeTextType type);
 	QComboBox* makeCombobox();
+	void alignTreeOn1stItemChanged();
 };
 
 #endif // FM_ENVELOPE_SET_EDIT_DIALOG_HPP

--- a/BambooTracker/gui/fm_envelope_set_edit_dialog.ui
+++ b/BambooTracker/gui/fm_envelope_set_edit_dialog.ui
@@ -108,18 +108,11 @@
    <item row="1" column="0" rowspan="7">
     <widget class="QTreeWidget" name="treeWidget">
      <property name="styleSheet">
-      <string notr="true">QTreeWidget::item {
-  height: 21px;
-}</string>
+      <string notr="true"/>
      </property>
      <property name="uniformRowHeights">
       <bool>true</bool>
      </property>
-     <column>
-      <property name="text">
-       <string notr="true">1</string>
-      </property>
-     </column>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
Fix #87.

On windows 10, 4b6e56b fixes the type alignment but it seems not to fix it on Linux.
In this commit, I add code to insert and remove a dummy row at the 2nd row when some change is performed on the 1st row. (I also fix to update digit type numbers when remove a row.)
@OPNA2608 could you check if this prevents misalignment on Linux?