### PR TITLE
VGM export for various chip targets

### DIFF
--- a/BambooTracker/bamboo_tracker.cpp
+++ b/BambooTracker/bamboo_tracker.cpp
@@ -957,7 +957,7 @@ bool BambooTracker::exportToWav(std::string file, int loopCnt, std::function<boo
 	}
 }
 
-bool BambooTracker::exportToVgm(std::string file, bool gd3TagEnabled, GD3Tag tag, std::function<bool()> f)
+bool BambooTracker::exportToVgm(std::string file, int target, bool gd3TagEnabled, GD3Tag tag, std::function<bool()> f)
 {
 	int tmpRate = opnaCtrl_->getRate();
 	opnaCtrl_->setRate(44100);
@@ -974,7 +974,7 @@ bool BambooTracker::exportToVgm(std::string file, bool gd3TagEnabled, GD3Tag tag
 	uint32_t loopPoint = 0;
 	uint32_t loopPointSamples = 0;
 	std::shared_ptr<chip::VgmExportContainer> exCntr
-			= std::make_shared<chip::VgmExportContainer>(mod_->getTickFrequency());
+			= std::make_shared<chip::VgmExportContainer>(target, mod_->getTickFrequency());
 	opnaCtrl_->setExportContainer(exCntr);
 	startPlayFromStart();
 	exCntr->forceMoveLoopPoint();
@@ -1004,7 +1004,7 @@ bool BambooTracker::exportToVgm(std::string file, bool gd3TagEnabled, GD3Tag tag
 	opnaCtrl_->setRate(tmpRate);
 
 	try {
-		ExportHandler::writeVgm(file, exCntr->getData(), CHIP_CLOCK, mod_->getTickFrequency(),
+		ExportHandler::writeVgm(file, target, exCntr->getData(), CHIP_CLOCK, mod_->getTickFrequency(),
 								loopFlag, loopPoint, exCntr->getSampleLength() - loopPointSamples,
 								exCntr->getSampleLength(), gd3TagEnabled, tag);
 		f();

--- a/BambooTracker/bamboo_tracker.hpp
+++ b/BambooTracker/bamboo_tracker.hpp
@@ -186,7 +186,7 @@ public:
 
 	// Export
 	bool exportToWav(std::string file, int loopCnt, std::function<bool()> f);
-	bool exportToVgm(std::string file, bool gd3TagEnabled, GD3Tag tag, std::function<bool()> f);
+	bool exportToVgm(std::string file, int target, bool gd3TagEnabled, GD3Tag tag, std::function<bool()> f);
 	bool exportToS98(std::string file, bool tagEnabled, S98Tag tag, std::function<bool()> f);
 
 	// Backup

--- a/BambooTracker/chips/export_container.cpp
+++ b/BambooTracker/chips/export_container.cpp
@@ -73,7 +73,11 @@ namespace chip
 		else if (cmdFmPortA && (offset & 0x100) == 0) {
 			bool compatible = true;
 
-			if (offset == 0x29) // Mode register
+			if (offset == 0x28) { // Key register
+				if (fm == Export_YM2203 && (value & 7) >= 3)
+					compatible = false;
+			}
+			else if (offset == 0x29) // Mode register
 				compatible = fm == Export_YM2608;
 			else if ((offset & 0xf0) == 0x10) // Rhythm section
 				compatible = fm == Export_YM2608;

--- a/BambooTracker/chips/export_container.hpp
+++ b/BambooTracker/chips/export_container.hpp
@@ -35,7 +35,7 @@ namespace chip
 	class VgmExportContainer : public ExportContainerInterface
 	{
 	public:
-		VgmExportContainer(uint32_t intrRate);
+		VgmExportContainer(int target, uint32_t intrRate);
 		bool isNeedSampleGeneration() const override { return false; }
 		void recordRegisterChange(uint32_t offset, uint8_t value) override;
 		void recordStream(int16_t* stream, size_t nSamples) override;
@@ -48,6 +48,7 @@ namespace chip
 
 	private:
 		std::vector<uint8_t> buf_;
+		int target_;
 		uint64_t lastWait_, totalSampCnt_;
 		uint32_t intrRate_;
 		bool isSetLoop_;

--- a/BambooTracker/gui/mainwindow.cpp
+++ b/BambooTracker/gui/mainwindow.cpp
@@ -2156,6 +2156,7 @@ void MainWindow::on_actionVGM_triggered()
 
 	try {
 		bool res = bt_->exportToVgm(file.toStdString(),
+									diag.getExportTarget(),
 									diag.enabledGD3(),
 									tag,
 									[&progress]() -> bool {

--- a/BambooTracker/gui/vgm_export_settings_dialog.cpp
+++ b/BambooTracker/gui/vgm_export_settings_dialog.cpp
@@ -1,5 +1,6 @@
 #include "vgm_export_settings_dialog.hpp"
 #include "ui_vgm_export_settings_dialog.h"
+#include "export_handler.hpp"
 #include <QTextCodec>
 
 VgmExportSettingsDialog::VgmExportSettingsDialog(QWidget *parent) :
@@ -9,6 +10,14 @@ VgmExportSettingsDialog::VgmExportSettingsDialog(QWidget *parent) :
 	ui->setupUi(this);
 
 	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+
+	for (QRadioButton *button : {
+			ui->ym2608RadioButton, ui->ym2612RadioButton, ui->ym2203RadioButton,
+			ui->internalSsgRadioButton, ui->ay8910PsgRadioButton })
+		connect(button, &QAbstractButton::toggled,
+				this, &VgmExportSettingsDialog::updateSupportInformation);
+
+	updateSupportInformation();
 }
 
 VgmExportSettingsDialog::~VgmExportSettingsDialog()
@@ -158,4 +167,57 @@ GD3Tag VgmExportSettingsDialog::getGD3Tag() const
 	tag.notes += endNull;
 
 	return tag;
+}
+
+int VgmExportSettingsDialog::getExportTarget() const
+{
+	int target = 0;
+
+	if (ui->ym2612RadioButton->isChecked())
+		target |= Export_YM2612;
+	else if (ui->ym2203RadioButton->isChecked())
+		target |= Export_YM2203;
+
+	if (ui->ay8910PsgRadioButton->isChecked())
+		target |= Export_AY8910Psg;
+	else if (ui->ym2149PsgRadioButton->isChecked())
+		target |= Export_YM2149Psg;
+
+	return target;
+}
+
+void VgmExportSettingsDialog::updateSupportInformation()
+{
+	int target = getExportTarget();
+	int channels;
+
+	int fm = target & Export_FmMask;
+	int ssg = target & Export_SsgMask;
+
+	switch (fm) {
+	default:
+		channels = 6;
+		break;
+	case Export_YM2203:
+		channels = 3;
+		break;
+	}
+
+	bool haveSsg = fm == Export_YM2608 || fm == Export_YM2203 || ssg != Export_InternalSsg;
+	bool haveRhythm = fm == Export_YM2608;
+	bool haveAdpcm = fm == Export_YM2608;
+
+	ui->supportFmChannelsLabel->setText(QString::number(channels));
+	ui->supportSsgLabel->setText(haveSsg ? tr("Yes") : tr("No"));
+	ui->supportRhythmLabel->setText(haveRhythm ? tr("Yes") : tr("No"));
+	ui->supportAdpcmLabel->setText(haveAdpcm ? tr("Yes") : tr("No"));
+
+	QPalette normalPalette = palette();
+	QPalette warnPalette = normalPalette;
+	warnPalette.setColor(QPalette::WindowText, QColor(0xef2929));
+
+	ui->supportFmChannelsLabel->setPalette((channels == 6) ? normalPalette : warnPalette);
+	ui->supportSsgLabel->setPalette(haveSsg ? normalPalette : warnPalette);
+	ui->supportRhythmLabel->setPalette(haveRhythm ? normalPalette : warnPalette);
+	ui->supportAdpcmLabel->setPalette(haveAdpcm ? normalPalette : warnPalette);
 }

--- a/BambooTracker/gui/vgm_export_settings_dialog.hpp
+++ b/BambooTracker/gui/vgm_export_settings_dialog.hpp
@@ -30,6 +30,10 @@ public:
 	QString getVgmCreator() const;
 	QString getNotes() const;
 	GD3Tag getGD3Tag() const;
+	int getExportTarget() const;
+
+private slots:
+	void updateSupportInformation();
 
 private:
 	Ui::VgmExportSettingsDialog *ui;

--- a/BambooTracker/gui/vgm_export_settings_dialog.ui
+++ b/BambooTracker/gui/vgm_export_settings_dialog.ui
@@ -6,24 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>444</width>
-    <height>490</height>
+    <width>491</width>
+    <height>622</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>VGM export settings</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" rowstretch="2,4,4">
-   <item row="2" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
+  <layout class="QGridLayout" name="gridLayout" rowstretch="2,0,0,0">
    <item row="0" column="0" rowspan="2">
     <widget class="QGroupBox" name="gd3GroupBox">
      <property name="title">
@@ -340,6 +330,230 @@
          </item>
          <item row="3" column="0" colspan="4">
           <widget class="QPlainTextEdit" name="notesPlainTextEdit"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Target</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QGroupBox" name="groupBox_2">
+        <property name="title">
+         <string>FM</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <widget class="QRadioButton" name="ym2608RadioButton">
+           <property name="text">
+            <string>YM2608 OPNA</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="ym2612RadioButton">
+           <property name="text">
+            <string>YM2612 OPN2</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="ym2203RadioButton">
+           <property name="text">
+            <string>YM2203 OPN</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="groupBox_3">
+        <property name="title">
+         <string>SSG</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <widget class="QRadioButton" name="internalSsgRadioButton">
+           <property name="text">
+            <string>OPN internal</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="ay8910PsgRadioButton">
+           <property name="text">
+            <string>AY-3-8910 PSG</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="ym2149PsgRadioButton">
+           <property name="text">
+            <string>YM2149 PSG</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="groupBox_4">
+        <property name="title">
+         <string>Support</string>
+        </property>
+        <layout class="QFormLayout" name="formLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>FM Channels</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="supportFmChannelsLabel">
+           <property name="frameShape">
+            <enum>QFrame::WinPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Sunken</enum>
+           </property>
+           <property name="text">
+            <string notr="true">6</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>SSG</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="supportSsgLabel">
+           <property name="frameShape">
+            <enum>QFrame::WinPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Sunken</enum>
+           </property>
+           <property name="text">
+            <string>Yes</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>Rhythm</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLabel" name="supportRhythmLabel">
+           <property name="frameShape">
+            <enum>QFrame::WinPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Sunken</enum>
+           </property>
+           <property name="text">
+            <string>Yes</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>ADPCM</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLabel" name="supportAdpcmLabel">
+           <property name="frameShape">
+            <enum>QFrame::WinPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Sunken</enum>
+           </property>
+           <property name="text">
+            <string>Yes</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>

--- a/BambooTracker/io/export_handler.hpp
+++ b/BambooTracker/io/export_handler.hpp
@@ -9,7 +9,7 @@ class ExportHandler
 {
 public:
 	static void writeWave(std::string path, std::vector<int16_t> samples, uint32_t rate);
-	static void writeVgm(std::string path, std::vector<uint8_t> samples, uint32_t clock, uint32_t rate,
+	static void writeVgm(std::string path, int target, std::vector<uint8_t> samples, uint32_t clock, uint32_t rate,
 						 bool loopFlag, uint32_t loopPoint, uint32_t loopSamples, uint32_t totalSamples,
 						 bool gd3TagEnabled, GD3Tag tag);
 	static void writeS98(std::string path, std::vector<uint8_t> samples, uint32_t clock, uint32_t rate,
@@ -17,4 +17,18 @@ public:
 
 private:
 	ExportHandler();
+};
+
+enum ExportTargetFlag
+{
+	/* target bits 0-2 : FM type */
+	Export_YM2608 = 0,
+	Export_YM2612 = 1,
+	Export_YM2203 = 2,
+	Export_FmMask = Export_YM2608|Export_YM2612|Export_YM2203,
+	/* target bit 3 : SSG type */
+	Export_InternalSsg = 0,
+	Export_AY8910Psg = 4,
+	Export_YM2149Psg = 8,
+	Export_SsgMask = Export_InternalSsg|Export_AY8910Psg|Export_YM2149Psg,
 };


### PR DESCRIPTION
#98
 
Add to VGM exporter an ability to output for a different chip, or separate AY chip.
Dialog is updated and displays feature availability for the target.

- FM : OPNA, OPN2, OPN
- SSG : Internal, AY8910, YM2149

YM2203 can use internal SSG but will be at different clock setting.

**Note:** I should really clean up the garbage register writes for chip other than OPNA

**Edit1:** have mixed up AY8910 type & flag fields, fixed
**Edit2:** rebased on master, eliminated conflict