### PR TITLE
Visual

### DIFF
--- a/BambooTracker/BambooTracker.pro
+++ b/BambooTracker/BambooTracker.pro
@@ -192,7 +192,8 @@ SOURCES += \
     gui/file_history_handler.cpp \
     gui/file_history.cpp \
     midi/midi.cpp \
-    gui/q_application_wrapper.cpp
+    gui/q_application_wrapper.cpp \
+    gui/wave_visual.cpp
 
 HEADERS += \
     gui/mainwindow.hpp \
@@ -365,7 +366,8 @@ HEADERS += \
     gui/file_history.hpp \
     midi/midi.hpp \
     midi/midi_def.h \
-    gui/q_application_wrapper.hpp
+    gui/q_application_wrapper.hpp \
+    gui/wave_visual.hpp
 
 FORMS += \
     gui/mainwindow.ui \

--- a/BambooTracker/bamboo_tracker.cpp
+++ b/BambooTracker/bamboo_tracker.cpp
@@ -2755,3 +2755,8 @@ size_t BambooTracker::getDefaultPatternSize(int songNum) const
 {
 	return mod_->getSong(songNum).getDefaultPatternSize();
 }
+
+void BambooTracker::getOutputHistory(int16_t* container)
+{
+	opnaCtrl_->getOutputHistory(container);
+}

--- a/BambooTracker/bamboo_tracker.hpp
+++ b/BambooTracker/bamboo_tracker.hpp
@@ -327,6 +327,8 @@ public:
 	size_t getPatternSizeFromOrderNumber(int songNum, int orderNum) const;
 	void setDefaultPatternSize(int songNum, size_t size);
 	size_t getDefaultPatternSize(int songNum) const;
+	/*----- Visual -----*/
+	void getOutputHistory(int16_t* container);
 
 private:
 	CommandManager comMan_;

--- a/BambooTracker/gui/color_palette.cpp
+++ b/BambooTracker/gui/color_palette.cpp
@@ -80,4 +80,8 @@ ColorPalette::ColorPalette()
 	ptnBorderColor = QColor::fromRgb(120, 120, 120, 255);
 	ptnMuteColor = QColor::fromRgb(255, 0, 0, 255);
 	ptnUnmuteColor = QColor::fromRgb(0, 255, 0, 255);
+
+	// Wave visual
+	wavBackColor = QColor::fromRgb(0, 0, 33, 255);
+	wavDrawColor = QColor::fromRgb(82, 179, 217, 255);
 }

--- a/BambooTracker/gui/color_palette.hpp
+++ b/BambooTracker/gui/color_palette.hpp
@@ -53,6 +53,10 @@ public:
 	QColor ptnMaskColor;
 	QColor ptnBorderColor;
 	QColor ptnMuteColor, ptnUnmuteColor;
+
+	// Wave visual
+	QColor wavBackColor;
+	QColor wavDrawColor;
 };
 
 #endif // COLOR_PALETTE_HPP

--- a/BambooTracker/gui/mainwindow.cpp
+++ b/BambooTracker/gui/mainwindow.cpp
@@ -388,6 +388,13 @@ MainWindow::MainWindow(std::weak_ptr<Configuration> config, QString filePath, QW
 		else startPlaySong();
 	});
 
+	/* Visuals */
+	ui->waveVisual->setColorPalette(palette_);
+	visualTimer_.reset(new QTimer);
+	visualTimer_->start(40);
+	QObject::connect(visualTimer_.get(), &QTimer::timeout,
+					 this, &MainWindow::updateVisuals);
+
 	/* Status bar */
 	statusDetail_ = new QLabel();
 	statusStyle_ = new QLabel();
@@ -2256,4 +2263,12 @@ void MainWindow::on_actionClear_triggered()
 void MainWindow::on_keyRepeatCheckBox_stateChanged(int arg1)
 {
 	config_.lock()->setKeyRepetition(arg1 == Qt::Checked);
+}
+
+void MainWindow::updateVisuals()
+{
+	int16_t wave[2 * OPNAController::OutputHistorySize];
+	bt_->getOutputHistory(wave);
+
+	ui->waveVisual->setStereoSamples(wave, OPNAController::OutputHistorySize);
 }

--- a/BambooTracker/gui/mainwindow.hpp
+++ b/BambooTracker/gui/mainwindow.hpp
@@ -64,6 +64,7 @@ private:
 	std::shared_ptr<AudioStream> stream_;
 	std::unique_ptr<QTimer> timer_;
 	/*std::unique_ptr<Timer> timer_;*/
+	std::unique_ptr<QTimer> visualTimer_;
 	std::shared_ptr<QUndoStack> comStack_;
 	std::shared_ptr<FileHistory> fileHistory_;
 
@@ -214,6 +215,7 @@ private slots:
 	void onNewTickSignaled();
 	void on_actionClear_triggered();
 	void on_keyRepeatCheckBox_stateChanged(int arg1);
+	void updateVisuals();
 
 	inline bool showUndoResetWarningDialog(QString text)
 	{

--- a/BambooTracker/gui/mainwindow.ui
+++ b/BambooTracker/gui/mainwindow.ui
@@ -34,7 +34,7 @@
      <number>0</number>
     </property>
     <item row="0" column="0" colspan="4">
-     <layout class="QHBoxLayout" name="horizontalLayout" stretch="4,2,2,2">
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="4,0,2,2,2">
       <property name="leftMargin">
        <number>9</number>
       </property>
@@ -48,28 +48,86 @@
        <number>9</number>
       </property>
       <item>
-       <widget class="QGroupBox" name="orderListGroupBox">
-        <property name="title">
-         <string>Order List</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_3">
-         <property name="leftMargin">
-          <number>3</number>
-         </property>
-         <property name="topMargin">
-          <number>3</number>
-         </property>
-         <property name="rightMargin">
-          <number>3</number>
-         </property>
-         <property name="bottomMargin">
-          <number>3</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="OrderListEditor" name="orderList"/>
-         </item>
-        </layout>
-       </widget>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QGroupBox" name="orderListGroupBox">
+          <property name="title">
+           <string>Order List</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_3">
+           <property name="leftMargin">
+            <number>3</number>
+           </property>
+           <property name="topMargin">
+            <number>3</number>
+           </property>
+           <property name="rightMargin">
+            <number>3</number>
+           </property>
+           <property name="bottomMargin">
+            <number>3</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="OrderListEditor" name="orderList"/>
+           </item>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <item>
+         <widget class="QGroupBox" name="visualGroupBox">
+          <property name="title">
+           <string>Visual</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_3">
+           <property name="leftMargin">
+            <number>3</number>
+           </property>
+           <property name="topMargin">
+            <number>3</number>
+           </property>
+           <property name="rightMargin">
+            <number>3</number>
+           </property>
+           <property name="bottomMargin">
+            <number>3</number>
+           </property>
+           <item>
+            <widget class="WaveVisual" name="waveVisual" native="true">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>200</width>
+               <height>80</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </item>
       <item>
        <layout class="QGridLayout" name="gridLayout_4">
@@ -454,7 +512,7 @@
      <x>0</x>
      <y>0</y>
      <width>900</width>
-     <height>21</height>
+     <height>17</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -1245,6 +1303,12 @@
    <class>OrderListEditor</class>
    <extends>QFrame</extends>
    <header>gui/order_list_editor/order_list_editor.hpp</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>WaveVisual</class>
+   <extends>QWidget</extends>
+   <header>gui/wave_visual.hpp</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/BambooTracker/gui/wave_visual.cpp
+++ b/BambooTracker/gui/wave_visual.cpp
@@ -1,0 +1,76 @@
+#include "gui/wave_visual.hpp"
+#include "gui/color_palette.hpp"
+#include <limits>
+#include <QPainter>
+#include <QDebug>
+
+WaveVisual::WaveVisual(QWidget *parent)
+	: QWidget(parent)
+{
+	setAttribute(Qt::WA_OpaquePaintEvent);
+}
+
+void WaveVisual::setColorPalette(std::weak_ptr<ColorPalette> palette)
+{
+	palette_ = palette;
+}
+
+void WaveVisual::setStereoSamples(const int16_t *buffer, size_t frames)
+{
+	// identify the highest of the 2 input signals
+	int32_t sum = 0;
+	for (size_t i = 0; i < frames; ++i) {
+		sum += std::abs(buffer[2 * i]);
+		sum -= std::abs(buffer[2 * i + 1]);
+	}
+
+	// use this signal as display data
+	samples_.resize(frames);
+	int16_t *samples = samples_.data();
+	for (size_t i = 0; i < frames; ++i)
+		samples[i] = buffer[2 * i + (sum < 0)];
+
+	repaint();
+}
+
+void WaveVisual::paintEvent(QPaintEvent *event)
+{
+	Q_UNUSED(event);
+	QPainter painter(this);
+
+	std::shared_ptr<ColorPalette> palette = palette_.lock();
+	if (!palette)
+		return;
+
+	int w = width();
+	int h = height();
+	painter.fillRect(0, 0, w, h, palette->wavBackColor);
+
+	const int16_t *samples = samples_.data();
+	size_t frames = samples_.size();
+	if (frames <= 0)
+		return;
+
+	painter.setPen(palette->wavDrawColor);
+
+	int lastY = h / 2;
+	for (int x = 0; x < w; ++x) {
+		size_t index = (size_t)(x * ((double)frames / w));
+
+		int16_t sample = samples[index];
+		const int16_t range = std::numeric_limits<int16_t>::max() / 2;
+		int y = (h / 2) - ((h / 2) * sample  / range);
+		painter.drawPoint(x, y);
+
+		// draw intermediate points
+		int y1 = lastY, y2 = y;
+		int yM = (y1 + y2) / 2;
+		while (y1 != y2) {
+			bool b = (y1 > yM) ^ (y1 > y2);
+			painter.drawPoint(x - !b, y1);
+			y1 += (y1 < y2) ? 1 : -1;
+		}
+
+		lastY = y;
+	}
+}

--- a/BambooTracker/gui/wave_visual.hpp
+++ b/BambooTracker/gui/wave_visual.hpp
@@ -1,0 +1,28 @@
+#ifndef WAVE_VISUAL_HPP
+#define WAVE_VISUAL_HPP
+
+#include <QWidget>
+#include <vector>
+#include <memory>
+#include <cstdint>
+
+class ColorPalette;
+
+class WaveVisual : public QWidget
+{
+	Q_OBJECT
+
+public:
+	explicit WaveVisual(QWidget *parent = nullptr);
+	void setColorPalette(std::weak_ptr<ColorPalette> palette);
+	void setStereoSamples(const int16_t *buffer, size_t frames);
+
+protected:
+	void paintEvent(QPaintEvent *event) override;
+
+private:
+	std::weak_ptr<ColorPalette> palette_;
+	std::vector<int16_t> samples_;
+};
+
+#endif // WAVE_VISUAL_HPP

--- a/BambooTracker/opna_controller.hpp
+++ b/BambooTracker/opna_controller.hpp
@@ -41,6 +41,9 @@ public:
 
 	// Stream samples
 	void getStreamSamples(int16_t* container, size_t nSamples);
+	void getOutputHistory(int16_t* history);
+
+	enum { OutputHistorySize = 1024 };
 
 	// Chip mode
 	void setMode(SongType mode);
@@ -61,6 +64,9 @@ private:
 	SongType mode_;
 
 	void initChip();
+
+	void fillOutputHistory(const int16_t* outputs, size_t nSamples);
+	void transferReadyHistory();
 
 	/*----- FM -----*/
 public:
@@ -252,6 +258,10 @@ private:
 	int sumNoteSldSSG_[3];
 	bool noteSldSSGSetFlag_;
 	int transposeSSG_[3];
+	std::unique_ptr<int16_t[]> outputHistory_;
+	size_t outputHistoryIndex_;
+	std::unique_ptr<int16_t[]> outputHistoryReady_;
+	std::mutex outputHistoryReadyMutex_;
 
 	void initSSG();
 


### PR DESCRIPTION
I try to add a nice visual of the generated waveform.
 
I'm storing the samples onto a circular buffer up to the capacity 1024. (~18.5 ms of signal)
When it's not busy, it will be transfered on a secondary buffer for thread-safe use.

The second commit adds the graphical widget.
The display is functional and nice, but I don't know too much how to lay it out without eating too much space. In this regard, current form is not very pleasing and should be rearranged.