### PR TITLE
send signal back into output history, not front

### DIFF
--- a/BambooTracker/opna_controller.cpp
+++ b/BambooTracker/opna_controller.cpp
@@ -74,7 +74,9 @@ bool OPNAController::isUsedSCCI() const
 void OPNAController::getStreamSamples(int16_t* container, size_t nSamples)
 {
 	opna_->mix(container, nSamples);
-	fillOutputHistory(container, std::min<size_t>(nSamples, OutputHistorySize));
+
+	size_t nHistory = std::min<size_t>(nSamples, OutputHistorySize);
+	fillOutputHistory(&container[2 * (nSamples - nHistory)], nHistory);
 }
 
 void OPNAController::getOutputHistory(int16_t* container)


### PR DESCRIPTION
I've just realized it's the back samples which should be sent in the history buffer, in case the buffer size used is larger than history.
If there is some variance in the requested block size, then a discontinuity could be seen.