### PR TITLE
Chip updates

### DIFF
--- a/BambooTracker/chips/mame/fm.c
+++ b/BambooTracker/chips/mame/fm.c
@@ -2569,11 +2569,12 @@ INLINE void ADPCMA_calc_chan( YM2610 *F2610, ADPCM_CH *ch )
 
 			ch->adpcm_acc += jedi_table[ch->adpcm_step + data];
 
+			/* the 12-bit accumulator wraps on the ym2610 and ym2608 (like the msm5205), it does not saturate (like the msm5218) */
+			ch->adpcm_acc &= 0xfff;
+
 			/* extend 12-bit signed int */
-			if (ch->adpcm_acc & ~0x7ff)
+			if (ch->adpcm_acc & 0x800)
 				ch->adpcm_acc |= ~0xfff;
-			else
-				ch->adpcm_acc &= 0xfff;
 
 			ch->adpcm_step += step_inc[data & 7];
 			Limit( ch->adpcm_step, 48*16, 0*16 );

--- a/BambooTracker/chips/nuked/ym3438.c
+++ b/BambooTracker/chips/nuked/ym3438.c
@@ -1267,14 +1267,13 @@ void OPNmod_RhythmGenerate(ym3438_t *chip)
 
                 chip->rhythm_adpcm_acc[channel] += adpcm_jedi_table[chip->rhythm_adpcm_step[channel] + data];
 
+                /* the 12-bit accumulator wraps on the ym2610 and ym2608 (like the msm5205), it does not saturate (like the msm5218) */
+                chip->rhythm_adpcm_acc[channel] &= 0xfff;
+
                 /* extend 12-bit signed int */
-                if (chip->rhythm_adpcm_acc[channel] & ~0x7ff)
+                if (chip->rhythm_adpcm_acc[channel] & 0x800)
                 {
                     chip->rhythm_adpcm_acc[channel] |= ~0xfff;
-                }
-                else
-                {
-                    chip->rhythm_adpcm_acc[channel] &= 0xfff;
                 }
 
                 chip->rhythm_adpcm_step[channel] += adpcm_step_inc[data & 7];

--- a/BambooTracker/chips/nuked/ym3438.c
+++ b/BambooTracker/chips/nuked/ym3438.c
@@ -1673,7 +1673,7 @@ Bit8u OPN2_Read(ym3438_t *chip, Bit32u port)
         }
     }
     /*OPN-MOD: read from PSG*/
-    else if ((port & 3) == 1)
+    if ((port & 3) == 1)
     {
         if (chip->address < 16)
         {


### PR DESCRIPTION
Add some minor things of little consequence.

- first is a backport of https://github.com/mamedev/mame/commit/f7465887710430dca424817bd54dc6df71c5d02c, a recent fix I have stumbled upon as I checked out updated sources
- second is a dumb logic error in Nuked-Mod I made, which prevents the PSG reading code to be ever entered, due to the value of `chip_type`. this is not of importance in context of BT, but might serve someone interested to reuse this code.