### PR TITLE
Enhanced macOS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,25 @@
 language: cpp
-os: linux
-dist: xenial
+
+matrix:
+  include:
+    - os: linux
+      dist: xenial
+    - os: osx
+      osx_image: xcode8.3
+
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:ubuntu-sdk-team/ppa'
+    packages:
+      - qt5-default
+      - qttools5-dev-tools
+      - qtmultimedia5-dev
+      - libqt5multimedia5-plugins
+      - libasound2-dev
+  homebrew:
+    packages:
+      - qt5
 
 git:
   depth: 3
@@ -10,10 +29,8 @@ branches:
     - master
 
 before_install:
-  - sudo add-apt-repository --yes ppa:ubuntu-sdk-team/ppa
-  - sudo apt update -qq
-  - sudo apt install qt5-default qttools5-dev-tools qtmultimedia5-dev libqt5multimedia5-plugins
-  - sudo apt install libasound2-dev
+  # osx: force linking of qt5 into PATH
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew link --force qt5; fi
 
 script:
   - cd BambooTracker

--- a/BambooTracker/gui/wave_visual.cpp
+++ b/BambooTracker/gui/wave_visual.cpp
@@ -3,6 +3,8 @@
 #include <limits>
 #include <QPainter>
 #include <QDebug>
+//Xcode 8.3: "no member names 'abs' in namespace 'std'
+#include <cstdlib>
 
 WaveVisual::WaveVisual(QWidget *parent)
 	: QWidget(parent)

--- a/BambooTracker/midi/RtMidi/RtMidi.pri
+++ b/BambooTracker/midi/RtMidi/RtMidi.pri
@@ -14,5 +14,5 @@ win32 {
 }
 macx {
     DEFINES += __MACOSX_CORE__
-    LIBS += -framework CoreMIDI
+    LIBS += -framework CoreMIDI -framework CoreAudio -framework CoreFoundation
 }


### PR DESCRIPTION
See: https://github.com/rerrahkr/BambooTracker/issues/96#issuecomment-481628594
RtMidi, besides CoreMIDI, also requires the CoreAudio and
CoreFoundation frameworks to compile on macOS.