### PR TITLE
Re-layout the oscilloscope

### DIFF
--- a/BambooTracker/configuration.cpp
+++ b/BambooTracker/configuration.cpp
@@ -29,6 +29,7 @@ Configuration::Configuration()
 	retrieveChannelState_ = false;
 	enableTranslation_ = true;
 	showFMDetuneSigned_ = false;
+	showWaveVisual_ = true;
 
 	// Edit settings
 	pageJumpLength_ = 4;
@@ -804,6 +805,16 @@ bool Configuration::getShowFMDetuneAsSigned() const
 	return showFMDetuneSigned_;
 }
 
+void Configuration::setShowWaveVisual(bool enabled)
+{
+	showWaveVisual_ = enabled;
+}
+
+bool Configuration::getShowWaveVisual() const
+{
+	return showWaveVisual_;
+}
+
 // Edit settings
 void Configuration::setPageJumpLength(size_t length)
 {
@@ -999,3 +1010,4 @@ std::vector<FMEnvelopeText> Configuration::getFMEnvelopeTexts() const
 {
 	return fmEnvelopeTexts_;
 }
+

--- a/BambooTracker/configuration.hpp
+++ b/BambooTracker/configuration.hpp
@@ -78,6 +78,8 @@ public:
 	bool getEnableTranslation() const;
 	void setShowFMDetuneAsSigned(bool enabled);
 	bool getShowFMDetuneAsSigned() const;
+	void setShowWaveVisual(bool enabled);
+	bool getShowWaveVisual() const;
 private:
 	bool warpCursor_, warpAcrossOrders_;
 	bool showRowNumHex_, showPrevNextOrders_;
@@ -85,6 +87,7 @@ private:
 	bool reverseFMVolumeOrder_, moveCursorToRight_;
 	bool retrieveChannelState_, enableTranslation_;
 	bool showFMDetuneSigned_;
+	bool showWaveVisual_;
 
 	// Edit settings
 public:

--- a/BambooTracker/gui/configuration_dialog.cpp
+++ b/BambooTracker/gui/configuration_dialog.cpp
@@ -41,6 +41,7 @@ ConfigurationDialog::ConfigurationDialog(std::weak_ptr<Configuration> config, QW
 	ui->generalSettingsListWidget->item(8)->setCheckState(toCheckState(configLocked->getRetrieveChannelState()));
 	ui->generalSettingsListWidget->item(9)->setCheckState(toCheckState(configLocked->getEnableTranslation()));
 	ui->generalSettingsListWidget->item(10)->setCheckState(toCheckState(configLocked->getShowFMDetuneAsSigned()));
+	ui->generalSettingsListWidget->item(11)->setCheckState(toCheckState(configLocked->getShowWaveVisual()));
 
 	// Edit settings
 	ui->pageJumpLengthSpinBox->setValue(static_cast<int>(configLocked->getPageJumpLength()));
@@ -196,6 +197,7 @@ void ConfigurationDialog::on_ConfigurationDialog_accepted()
 	configLocked->setRetrieveChannelState(fromCheckState(ui->generalSettingsListWidget->item(8)->checkState()));
 	configLocked->setEnableTranslation(fromCheckState(ui->generalSettingsListWidget->item(9)->checkState()));
 	configLocked->setShowFMDetuneAsSigned(fromCheckState(ui->generalSettingsListWidget->item(10)->checkState()));
+	configLocked->setShowWaveVisual(fromCheckState(ui->generalSettingsListWidget->item(11)->checkState()));
 
 	// Edit settings
 	configLocked->setPageJumpLength(static_cast<size_t>(ui->pageJumpLengthSpinBox->value()));
@@ -284,6 +286,9 @@ void ConfigurationDialog::on_generalSettingsListWidget_itemSelectionChanged()
 		break;
 	case 10:	// Show FM detune as signed
 		text = tr("Display FM detune values as signed numbers in the FM envelope editor.");
+		break;
+	case 11:	// Show wave visual
+		text = tr("Enable an oscilloscope which displays a waveform of the sound output.");
 		break;
 	default:
 		text = "";

--- a/BambooTracker/gui/configuration_dialog.ui
+++ b/BambooTracker/gui/configuration_dialog.ui
@@ -143,6 +143,14 @@
               <enum>Unchecked</enum>
              </property>
             </item>
+            <item>
+             <property name="text">
+              <string>Show wave visual</string>
+             </property>
+             <property name="checkState">
+              <enum>Checked</enum>
+             </property>
+            </item>
            </widget>
           </item>
           <item row="1" column="0">

--- a/BambooTracker/gui/configuration_handler.cpp
+++ b/BambooTracker/gui/configuration_handler.cpp
@@ -44,6 +44,7 @@ bool ConfigurationHandler::saveConfiguration(std::weak_ptr<Configuration> config
 		settings.setValue("retrieveChannelState",	configLocked->getRetrieveChannelState());
 		settings.setValue("enableTranslation",		configLocked->getEnableTranslation());
 		settings.setValue("showFMDetuneAsSigned",	configLocked->getShowFMDetuneAsSigned());
+		settings.setValue("showWaveVisual",		configLocked->getShowWaveVisual());
 		settings.endGroup();
 
 		// Edit settings
@@ -191,6 +192,7 @@ bool ConfigurationHandler::loadConfiguration(std::weak_ptr<Configuration> config
 		configLocked->setRetrieveChannelState(settings.value("retrieveChannelState", configLocked->getRetrieveChannelState()).toBool());
 		configLocked->setEnableTranslation(settings.value("enableTranslation", configLocked->getEnableTranslation()).toBool());
 		configLocked->setShowFMDetuneAsSigned(settings.value("showFMDetuneAsSigned", configLocked->getShowFMDetuneAsSigned()).toBool());
+		configLocked->setShowWaveVisual(settings.value("showWaveVisual", configLocked->getShowWaveVisual()).toBool());
 		settings.endGroup();
 
 		// Edit settings

--- a/BambooTracker/gui/mainwindow.cpp
+++ b/BambooTracker/gui/mainwindow.cpp
@@ -70,6 +70,7 @@ MainWindow::MainWindow(std::weak_ptr<Configuration> config, QString filePath, QW
 	resize(config.lock()->getMainWindowWidth(), config.lock()->getMainWindowHeight());
 	if (config.lock()->getMainWindowMaximized()) showMaximized();
 	ui->actionFollow_Mode->setChecked(config.lock()->getFollowMode());
+	ui->visualFrame->setVisible(config_.lock()->getShowWaveVisual());
 	bt_->setFollowPlay(config.lock()->getFollowMode());
 
 	setMidiConfiguration();
@@ -1137,6 +1138,8 @@ void MainWindow::changeConfiguration()
 	instForms_->updateByConfiguration();
 
 	bt_->changeConfiguration(config_);
+
+	ui->visualFrame->setVisible(config_.lock()->getShowWaveVisual());
 
 	update();
 }

--- a/BambooTracker/gui/mainwindow.ui
+++ b/BambooTracker/gui/mainwindow.ui
@@ -76,58 +76,72 @@
        </layout>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_4">
-        <item>
-         <widget class="QGroupBox" name="visualGroupBox">
-          <property name="title">
-           <string>Visual</string>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_3">
-           <property name="leftMargin">
-            <number>3</number>
+       <widget class="QFrame" name="visualFrame">
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QGroupBox" name="visualGroupBox">
+           <property name="title">
+            <string>Visual</string>
            </property>
-           <property name="topMargin">
-            <number>3</number>
+           <layout class="QVBoxLayout" name="verticalLayout_3">
+            <property name="leftMargin">
+             <number>3</number>
+            </property>
+            <property name="topMargin">
+             <number>3</number>
+            </property>
+            <property name="rightMargin">
+             <number>3</number>
+            </property>
+            <property name="bottomMargin">
+             <number>3</number>
+            </property>
+            <item>
+             <widget class="WaveVisual" name="waveVisual" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>80</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
            </property>
-           <property name="rightMargin">
-            <number>3</number>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
            </property>
-           <property name="bottomMargin">
-            <number>3</number>
-           </property>
-           <item>
-            <widget class="WaveVisual" name="waveVisual" native="true">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>200</width>
-               <height>80</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
       </item>
       <item>
        <layout class="QGridLayout" name="gridLayout_4">


### PR DESCRIPTION
I arranged the oscilloscope positioning, according to multiple attempts and personal preference.
The inconvenience is the reduction of height of the instruments panel.
Despite it, the program will be able to resize more easily to a smaller size.

Also, I add a setting which can turn on/off the display, like deflemask.
Some users may prefer to avoid a source of distraction.