### PR TITLE
Add export targets to S98

### DIFF
--- a/BambooTracker/bamboo_tracker.cpp
+++ b/BambooTracker/bamboo_tracker.cpp
@@ -1014,7 +1014,7 @@ bool BambooTracker::exportToVgm(std::string file, int target, bool gd3TagEnabled
 	}
 }
 
-bool BambooTracker::exportToS98(std::string file, bool tagEnabled, S98Tag tag, std::function<bool()> f)
+bool BambooTracker::exportToS98(std::string file, int target, bool tagEnabled, S98Tag tag, std::function<bool()> f)
 {
 	int tmpRate = opnaCtrl_->getRate();
 	opnaCtrl_->setRate(44100);
@@ -1029,7 +1029,7 @@ bool BambooTracker::exportToS98(std::string file, bool tagEnabled, S98Tag tag, s
 	bool tmpFollow = isFollowPlay_;
 	isFollowPlay_ = false;
 	uint32_t loopPoint = 0;
-	std::shared_ptr<chip::S98ExportContainer> exCntr = std::make_shared<chip::S98ExportContainer>();
+	std::shared_ptr<chip::S98ExportContainer> exCntr = std::make_shared<chip::S98ExportContainer>(target);
 	opnaCtrl_->setExportContainer(exCntr);
 	startPlayFromStart();
 	exCntr->forceMoveLoopPoint();
@@ -1059,7 +1059,7 @@ bool BambooTracker::exportToS98(std::string file, bool tagEnabled, S98Tag tag, s
 	opnaCtrl_->setRate(tmpRate);
 
 	try {
-		ExportHandler::writeS98(file, exCntr->getData(), CHIP_CLOCK, 44100,
+		ExportHandler::writeS98(file, target, exCntr->getData(), CHIP_CLOCK, 44100,
 								loopFlag, loopPoint, tagEnabled, tag);
 		f();
 		return true;

--- a/BambooTracker/bamboo_tracker.hpp
+++ b/BambooTracker/bamboo_tracker.hpp
@@ -187,7 +187,7 @@ public:
 	// Export
 	bool exportToWav(std::string file, int loopCnt, std::function<bool()> f);
 	bool exportToVgm(std::string file, int target, bool gd3TagEnabled, GD3Tag tag, std::function<bool()> f);
-	bool exportToS98(std::string file, bool tagEnabled, S98Tag tag, std::function<bool()> f);
+	bool exportToS98(std::string file, int target, bool tagEnabled, S98Tag tag, std::function<bool()> f);
 
 	// Backup
 	void backupModule(std::string file);

--- a/BambooTracker/chips/export_container.hpp
+++ b/BambooTracker/chips/export_container.hpp
@@ -60,7 +60,7 @@ namespace chip
 	class S98ExportContainer : public ExportContainerInterface
 	{
 	public:
-		S98ExportContainer();
+		explicit S98ExportContainer(int target);
 		bool isNeedSampleGeneration() const override { return false; }
 		void recordRegisterChange(uint32_t offset, uint8_t value) override;
 		void recordStream(int16_t* stream, size_t nSamples) override;
@@ -73,6 +73,7 @@ namespace chip
 
 	private:
 		std::vector<uint8_t> buf_;
+		int target_;
 		uint64_t lastWait_, totalSampCnt_;
 		bool isSetLoop_;
 		uint32_t loopPoint_;

--- a/BambooTracker/gui/mainwindow.cpp
+++ b/BambooTracker/gui/mainwindow.cpp
@@ -2240,6 +2240,7 @@ void MainWindow::on_actionS98_triggered()
 
 	try {
 		bool res = bt_->exportToS98(file.toStdString(),
+									diag.getExportTarget(),
 									diag.enabledTag(),
 									tag,
 									[&progress]() -> bool {

--- a/BambooTracker/gui/s98_export_settings_dialog.cpp
+++ b/BambooTracker/gui/s98_export_settings_dialog.cpp
@@ -1,5 +1,6 @@
 #include "s98_export_settings_dialog.hpp"
 #include "ui_s98_export_settings_dialog.h"
+#include "export_handler.hpp"
 
 S98ExportSettingsDialog::S98ExportSettingsDialog(QWidget *parent) :
 	QDialog(parent),
@@ -8,6 +9,14 @@ S98ExportSettingsDialog::S98ExportSettingsDialog(QWidget *parent) :
 	ui->setupUi(this);
 
 	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+
+	for (QRadioButton *button : {
+			ui->ym2608RadioButton, ui->ym2612RadioButton, ui->ym2203RadioButton,
+			ui->internalSsgRadioButton, ui->ay8910PsgRadioButton })
+		connect(button, &QAbstractButton::toggled,
+				this, &S98ExportSettingsDialog::updateSupportInformation);
+
+	updateSupportInformation();
 }
 
 S98ExportSettingsDialog::~S98ExportSettingsDialog()
@@ -33,4 +42,57 @@ S98Tag S98ExportSettingsDialog::getS98Tag() const
 	tag.s98by = ui->s98byLineEdit->text().toUtf8().toStdString();
 	tag.system = ui->systemLineEdit->text().toUtf8().toStdString();
 	return tag;
+}
+
+int S98ExportSettingsDialog::getExportTarget() const
+{
+	int target = 0;
+
+	if (ui->ym2612RadioButton->isChecked())
+		target |= Export_YM2612;
+	else if (ui->ym2203RadioButton->isChecked())
+		target |= Export_YM2203;
+
+	if (ui->ay8910PsgRadioButton->isChecked())
+		target |= Export_AY8910Psg;
+	else if (ui->ym2149PsgRadioButton->isChecked())
+		target |= Export_YM2149Psg;
+
+	return target;
+}
+
+void S98ExportSettingsDialog::updateSupportInformation()
+{
+	int target = getExportTarget();
+	int channels;
+
+	int fm = target & Export_FmMask;
+	int ssg = target & Export_SsgMask;
+
+	switch (fm) {
+	default:
+		channels = 6;
+		break;
+	case Export_YM2203:
+		channels = 3;
+		break;
+	}
+
+	bool haveSsg = fm == Export_YM2608 || fm == Export_YM2203 || ssg != Export_InternalSsg;
+	bool haveRhythm = fm == Export_YM2608;
+	bool haveAdpcm = fm == Export_YM2608;
+
+	ui->supportFmChannelsLabel->setText(QString::number(channels));
+	ui->supportSsgLabel->setText(haveSsg ? tr("Yes") : tr("No"));
+	ui->supportRhythmLabel->setText(haveRhythm ? tr("Yes") : tr("No"));
+	ui->supportAdpcmLabel->setText(haveAdpcm ? tr("Yes") : tr("No"));
+
+	QPalette normalPalette = palette();
+	QPalette warnPalette = normalPalette;
+	warnPalette.setColor(QPalette::WindowText, QColor(0xef2929));
+
+	ui->supportFmChannelsLabel->setPalette((channels == 6) ? normalPalette : warnPalette);
+	ui->supportSsgLabel->setPalette(haveSsg ? normalPalette : warnPalette);
+	ui->supportRhythmLabel->setPalette(haveRhythm ? normalPalette : warnPalette);
+	ui->supportAdpcmLabel->setPalette(haveAdpcm ? normalPalette : warnPalette);
 }

--- a/BambooTracker/gui/s98_export_settings_dialog.hpp
+++ b/BambooTracker/gui/s98_export_settings_dialog.hpp
@@ -18,6 +18,10 @@ public:
 
 	bool enabledTag() const;
 	S98Tag getS98Tag() const;
+	int getExportTarget() const;
+
+private slots:
+	void updateSupportInformation();
 
 private:
 	Ui::S98ExportSettingsDialog *ui;

--- a/BambooTracker/gui/s98_export_settings_dialog.ui
+++ b/BambooTracker/gui/s98_export_settings_dialog.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>300</width>
-    <height>320</height>
+    <width>491</width>
+    <height>501</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>S98 export settings</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
     <widget class="QGroupBox" name="tagGroupBox">
      <property name="title">
@@ -115,6 +115,220 @@
         <property name="text">
          <string>NEC PC-9801</string>
         </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Target</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QGroupBox" name="groupBox_2">
+        <property name="title">
+         <string>FM</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <widget class="QRadioButton" name="ym2608RadioButton">
+           <property name="text">
+            <string>YM2608 OPNA</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="ym2612RadioButton">
+           <property name="text">
+            <string>YM2612 OPN2</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="ym2203RadioButton">
+           <property name="text">
+            <string>YM2203 OPN</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="groupBox_3">
+        <property name="title">
+         <string>SSG</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <widget class="QRadioButton" name="internalSsgRadioButton">
+           <property name="text">
+            <string>OPN internal</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="ay8910PsgRadioButton">
+           <property name="text">
+            <string>AY-3-8910 PSG</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="ym2149PsgRadioButton">
+           <property name="text">
+            <string>YM2149 PSG</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="groupBox_4">
+        <property name="title">
+         <string>Support</string>
+        </property>
+        <layout class="QFormLayout" name="formLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>FM Channels</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="supportFmChannelsLabel">
+           <property name="frameShape">
+            <enum>QFrame::WinPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Sunken</enum>
+           </property>
+           <property name="text">
+            <string notr="true">6</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>SSG</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="supportSsgLabel">
+           <property name="frameShape">
+            <enum>QFrame::WinPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Sunken</enum>
+           </property>
+           <property name="text">
+            <string>Yes</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>Rhythm</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLabel" name="supportRhythmLabel">
+           <property name="frameShape">
+            <enum>QFrame::WinPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Sunken</enum>
+           </property>
+           <property name="text">
+            <string>Yes</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>ADPCM</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLabel" name="supportAdpcmLabel">
+           <property name="frameShape">
+            <enum>QFrame::WinPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Sunken</enum>
+           </property>
+           <property name="text">
+            <string>Yes</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>

--- a/BambooTracker/io/export_handler.hpp
+++ b/BambooTracker/io/export_handler.hpp
@@ -12,7 +12,7 @@ public:
 	static void writeVgm(std::string path, int target, std::vector<uint8_t> samples, uint32_t clock, uint32_t rate,
 						 bool loopFlag, uint32_t loopPoint, uint32_t loopSamples, uint32_t totalSamples,
 						 bool gd3TagEnabled, GD3Tag tag);
-	static void writeS98(std::string path, std::vector<uint8_t> samples, uint32_t clock, uint32_t rate,
+	static void writeS98(std::string path, int target, std::vector<uint8_t> samples, uint32_t clock, uint32_t rate,
 						 bool loopFlag, uint32_t loopPoint, bool tagEnabled, S98Tag tag);
 
 private:


### PR DESCRIPTION
This is to complete the second part of task #98.

Now, S98 can be exported in the same way as VGM.
The file header can contain 2 device info blocks when a PSG is used.

The FM will map to command 00-01.
The PSG, if used, will map to 02 and 03(unused).