### PR TITLE
Resolve warning 'catching polymorphic type by value'

### DIFF
--- a/BambooTracker/gui/mainwindow.cpp
+++ b/BambooTracker/gui/mainwindow.cpp
@@ -515,7 +515,7 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
 		Qt::Key qtKey = static_cast<Qt::Key> (key);
 		try {
 			bt_->jamKeyOn (getJamKeyFromLayoutMapping (qtKey));
-		} catch (std::invalid_argument) {}
+		} catch (std::invalid_argument &) {}
 	}
 }
 
@@ -528,7 +528,7 @@ void MainWindow::keyReleaseEvent(QKeyEvent *event)
 		Qt::Key qtKey = static_cast<Qt::Key> (key);
 		try {
 			bt_->jamKeyOff (getJamKeyFromLayoutMapping (qtKey));
-		} catch (std::invalid_argument) {}
+		} catch (std::invalid_argument &) {}
 	}
 }
 

--- a/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
+++ b/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
@@ -880,7 +880,7 @@ bool PatternEditorPanel::enterToneData(QKeyEvent* event)
 					break;
 			}
 			setStepKeyOn (JamManager::jamKeyToNote (possibleJamKey), baseOct + octaveOffset);
-		} catch (std::invalid_argument) {}
+		} catch (std::invalid_argument &) {}
 	}
 
 	return false;


### PR DESCRIPTION
It's a warning of GCC 8 which identifies the `catch` part as potential source of problems.