### PR TITLE
Fallback in case system MIDI cannot be opened

### DIFF
--- a/BambooTracker/midi/RtMidi/RtMidi.pri
+++ b/BambooTracker/midi/RtMidi/RtMidi.pri
@@ -16,3 +16,5 @@ macx {
     DEFINES += __MACOSX_CORE__
     LIBS += -framework CoreMIDI -framework CoreAudio -framework CoreFoundation
 }
+
+DEFINES += __RTMIDI_DUMMY__

--- a/BambooTracker/midi/midi.cpp
+++ b/BambooTracker/midi/midi.cpp
@@ -33,14 +33,32 @@ void MidiInterface::switchApi(RtMidi::Api api)
 	if (inputClient_ && api == inputClient_->getCurrentApi())
 		return;
 
-	RtMidiIn *inputClient = new RtMidiIn(api, MIDI_INP_CLIENT_NAME, MidiBufferSize);
+	RtMidiIn *inputClient = nullptr;
+	try {
+		inputClient = new RtMidiIn(api, MIDI_INP_CLIENT_NAME, MidiBufferSize);
+	}
+	catch (RtMidiError &error) {
+		fprintf(stderr, "Cannot initialize MIDI In.\n");
+	}
+	if (!inputClient)
+		inputClient = new RtMidiIn(RtMidi::RTMIDI_DUMMY, MIDI_INP_CLIENT_NAME, MidiBufferSize);
+
 	inputClient->ignoreTypes(MIDI_INP_IGNORE_SYSEX, MIDI_INP_IGNORE_TIME, MIDI_INP_IGNORE_SENSE);
 	inputClient_.reset(inputClient);
 	inputClient->setErrorCallback(&onMidiError, this);
 	inputClient->setCallback(&onMidiInput, this);
 	hasOpenInputPort_ = false;
 
-	RtMidiOut *outputClient = new RtMidiOut(api, MIDI_OUT_CLIENT_NAME);
+	RtMidiOut *outputClient = nullptr;
+	try {
+		outputClient = new RtMidiOut(api, MIDI_OUT_CLIENT_NAME);
+	}
+	catch (RtMidiError &error) {
+		fprintf(stderr, "Cannot initialize MIDI Out.\n");
+	}
+	if (!outputClient)
+		outputClient = new RtMidiOut(RtMidi::RTMIDI_DUMMY, MIDI_OUT_CLIENT_NAME);
+
 	outputClient_.reset(outputClient);
 	outputClient->setErrorCallback(&onMidiError, this);
 	hasOpenOutputPort_ = false;


### PR DESCRIPTION
#172

This prevents BT crashing in case the MIDI system fails to open for any reason.

Verified as working on Linux ALSA.
I have set zero permissions on the device node for testing.

It needs to force rebuild RtMidi.cpp with a definition which enables dummy mode.