### PR TITLE
Handle test builds & releases via Travis CI, Publish proper debug builds for Win(XP,7+) and macOS on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,6 +31,7 @@ skip_commits:
 clone_depth: 3  # clone entire repository history if not defined
 
 environment:
+  APPVEYOR_YML_DISABLE_PS_LINUX: true
   matrix:
     # Windows 7 or later
     - APPVEYOR_JOB_NAME: for Windows 7 or later
@@ -38,12 +39,18 @@ environment:
       COMPILER: C:\Qt\Tools\mingw530_32\bin
       QT: C:\Qt\5.10.1\mingw53_32\bin
       DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-dev.zip
+      MAKE: mingw32-make
     # Windows XP
     - APPVEYOR_JOB_NAME: for Windows XP
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       COMPILER: C:\Qt\Tools\mingw492_32\bin
       QT: C:\Qt\5.5\mingw492_32\bin
       DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-dev-winXP.zip
+      MAKE: mingw32-make
+    - APPVEYOR_JOB_NAME: for macOS (Modern)
+      APPVEYOR_BUILD_WORKER_IMAGE: macOS-Mojave
+      DEST: BambooTracker-v$APPVEYOR_BUILD_VERSION-dev-macos.zip
+      MAKE: make
 
 # scripts that run after cloning repository
 install:
@@ -59,28 +66,38 @@ platform: x86
 
 # scripts to run before build
 before_build:
-  - set PATH=%QT%;%COMPILER%;%PATH%
+  - ps: $env:Path = "$env:QT;$env:COMPILER;$env:Path"
+  - sh: |
+      brew install qt jack p7zip
+      export PATH="/usr/local/opt/qt/bin:$PATH"
+      export JACKLIB="/usr/local/opt/jack/lib"
+      export JACKINC="/usr/local/opt/jack/include"
   - cd BambooTracker
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:
-  - qmake BambooTracker.pro CONFIG+=release CONFIG-=debug
-  - mingw32-make
-  - md bin
-  - copy release\BambooTracker.exe bin
-  - cd bin
-  - windeployqt BambooTracker.exe
-  - ren translations lang
-  - cd ..
-  - copy .qm\*.qm bin\lang
+  - ps: |
+      qmake.exe BambooTracker.pro CONFIG+=debug CONFIG+=console CONFIG+=nostrip
+      & $env:MAKE -j2
+      # Fixes AppVeyor build erroring out...?
+      echo "=== BUILDING DONE ==="
+  - sh: |
+      qmake BambooTracker.pro CONFIG+=debug CONFIG+=console CONFIG+=nostrip LIBS+=-L"$JACKLIB" INCLUDEPATH+="$JACKINC"
+      $MAKE -j2
 
 # scripts to run after build (working directory and environment changes are persisted from the previous steps)
 after_build:
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - set DEPLOY_FILES=%APPVEYOR_BUILD_FOLDER%\BambooTracker\bin\*
-  - set DEPLOY_FILES=%DEPLOY_FILES% licenses img demos specs skins
-  - set DEPLOY_FILES=%DEPLOY_FILES% *.md LICENSE
-  - 7z a -tzip %DEST% %DEPLOY_FILES%
+  - cd ..
+  - mkdir packaging
+  - cd packaging
+  - ps: |
+      Copy-Item -Recurse ..\BambooTracker\debug\BambooTracker.exe,..\img,..\demos,..\licenses,..\specs,..\skins,..\*.md,..\LICENSE .
+      windeployqt.exe BambooTracker.exe -verbose=2
+      mv translations lang
+      mv ..\BambooTracker\.qm\*.qm lang\
+  - sh: bash ../ci/package_osx.sh
+  - ps: 7z a -tzip "..\$env:DEST" *
+  - sh: 7z a -tzip "../$DEST" *
 
 #---------------------------------#
 #      artifacts configuration    #

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,111 @@
 language: cpp
 
-matrix:
+jobs:
   include:
-    - os: linux
-      dist: xenial
-    - os: osx
+    - name: Windows (7 and later)
+      os: windows
+      env:
+        - TARGET_OS=windows
+        - MAKE=mingw32-make
+        - QMAKE=qmake.exe
+        - MINGWPATH=/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw32
+        - MINGWVER=7.3.0
+        - QTDIR=$HOME/Qt/win7
+        - QTVER=5.14.1
+        - QTTCH=win32_mingw73
+      cache:
+        directories:
+          - $MINGWPATH
+          - $HOME/Qt
+      before_install:
+        # Check if dependencies are cached, otherwise fetch them.
+        - bash "$TRAVIS_BUILD_DIR"/ci/fetch_mingw.sh "$MINGWPATH" "$MINGWVER"
+        - bash "$TRAVIS_BUILD_DIR"/ci/fetch_qt.sh "$QTDIR" "$QTVER" "$QTTCH"
+          qtbase qtmultimedia qttools
+        - export QTPATH="$(echo "$QTDIR"/"$QTVER"/*)"
+        - export PATH="$MINGWPATH"/bin:"$QTPATH"/bin:"$PATH"
+    - name: Windows (XP)
+      os: windows
+      env:
+        - TARGET_OS=windows-xp
+        - MAKE=mingw32-make
+        - QMAKE=qmake.exe
+        - MINGWPATH=/c/tools/mingw32
+        - MINGWVER=4.9.3
+        - QTDIR=$HOME/Qt/winXP
+        - QTVER=5.5
+        - QTTCH=win32_mingw492
+      cache:
+        directories:
+          - $MINGWPATH
+          - $HOME/Qt
+      before_install:
+        # Check if dependencies are cached, otherwise fetch them.
+        - bash "$TRAVIS_BUILD_DIR"/ci/fetch_mingw.sh "$MINGWPATH" "$MINGWVER"
+        - bash "$TRAVIS_BUILD_DIR"/ci/fetch_qt.sh "$QTDIR" "$QTVER" "$QTTCH"
+          essentials addons
+        - export QTPATH="$(echo "$QTDIR"/"$QTVER"/*)"
+        - export PATH="$MINGWPATH"/bin:"$QTPATH"/bin:"$PATH"
+
+    - name: macOS (Xcode 11.3)
+      os: osx
+      osx_image: xcode11.3
+      env:
+        - TARGET_OS=macos
+        - MAKE=make
+        - QMAKE="qmake DEFINES+=__UNIX_JACK__"
+      before_install:
+        # Force linking of Qt into PATH
+        - brew link --force qt
+        # Manually append JACK includes to qmake,
+        # it doesn't seem to pick them up on its own (forcing linking didn't help)
+        - JACKLIB=$(find /usr/local/Cellar/jack/ -type d -name lib)
+        - JACKINC=$(find /usr/local/Cellar/jack/ -type d -name include)
+        - export QMAKE="$QMAKE LIBS+=-L$JACKLIB INCLUDEPATH+=$JACKINC"
+    - name: macOS (Xcode 9.3)
+      os: osx
       osx_image: xcode9.3
+      env:
+        - TARGET_OS=macos-legacy
+        - MAKE=make
+        - QMAKE="qmake DEFINES+=__UNIX_JACK__"
+      before_install:
+        # Force linking of Qt into PATH
+        - brew link --force qt
+        # Manually append JACK includes to qmake,
+        # it doesn't seem to pick them up on its own (forcing linking didn't help)
+        - JACKLIB=$(find /usr/local/Cellar/jack/ -type d -name lib)
+        - JACKINC=$(find /usr/local/Cellar/jack/ -type d -name include)
+        - export QMAKE="$QMAKE LIBS+=-L$JACKLIB INCLUDEPATH+=$JACKINC"
+
+    - name: Linux (Ubuntu 16.04)
+      os: linux
+      dist: xenial
+      env:
+        - TARGET_OS=linux
+        - MAKE=make
+        - QMAKE="qmake DEFINES+=__LINUX_PULSE__ DEFINES+=__UNIX_JACK__"
+      # no deployment phase, manual build is preferred on Linux
+      # TODO consider Appimage?
 
 addons:
+  homebrew:
+    packages:
+      - jack
+      - qt
+      - p7zip
+    update: true
   apt:
     sources:
-      - sourceline: 'ppa:ubuntu-sdk-team/ppa'
+      - sourceline: ppa:ubuntu-sdk-team/ppa
     packages:
       - qt5-default
       - qttools5-dev-tools
       - qtmultimedia5-dev
       - libqt5multimedia5-plugins
       - libasound2-dev
-      - libjack-dev
       - libpulse-dev
-  homebrew:
-    packages:
-      - qt
-    update: true
+      - libjack-dev
 
 git:
   depth: 3
@@ -32,30 +115,25 @@ branches:
     - master
     - "/^v[0-9\\.]+$/"
 
-before_install:
-  # osx: force linking of qt into PATH
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew link --force qt; fi
-
 script:
   - cd BambooTracker
-  - qmake
-  - make
+  - "$QMAKE CONFIG+=release CONFIG-=debug"
+  - "$MAKE -j2"
+  - cd ..
 
 before_deploy:
-  - macdeployqt BambooTracker.app -verbose=2
-  - mv .qm lang
-  - mv lang BambooTracker.app/Contents/Resources
-  - mv BambooTracker.app ..
-  - cd ..
-  - zip -r BambooTracker-$TRAVIS_TAG-macOS.zip BambooTracker.app *.md img demos licenses specs skins LICENSE
+  - mkdir build
+  - cd build
+  - bash "$TRAVIS_BUILD_DIR"/ci/package_"$TRAVIS_OS_NAME".sh
+  - 7z a -tzip "$TRAVIS_BUILD_DIR"/BambooTracker-"$TRAVIS_TAG"-"$TARGET_OS".zip *
 
 deploy:
   provider: releases
-  api_key:
+  token:
     secure: bs+nLxg+IeepN/gyUHN//I1pPvKDMXiAGF7aE8vOW7c6ZeJMoUIGydJkNzsPWIKnRhMa5RYlOXM+9/eMzYe0JAC2cVj/Zo2IMeRVYqeQDrKZ1my6CMGGvE0dUnSHXIezN0+Z4SP+p6HRRF20FLqthz/3ICWiqoSo1/HFHnj5nDCG2Ni++Xt5PFVBOa6sp9CzDBtm9I8xBwoieZFwUpU/BMOqlHHHoQ09YSdzCdu0E544bAh7RXgmyl+ayYD8klVhf5p82oynnMliAdj0IOlPRETyBhhdXXv5/Eivtoo9e5bvlbEwuuy8yvbZl9LW0fQLobB2o/2eYNtDpxOciLOZQaj8EvjhOPVeyAlEKi28VOusYFVrGk3UEuN5HoxMPdwWRJWylgcsYd1ZWS907ccj9XLrF4bVpyPOhvYiLA1zgIU+nk5B7NWqzQjcNEQK4jx+UeJURLpZMS8F1lyLlNJeWr3b5E0+6+nTmgeq5E7jGwdhUraje6W5hmXlwrKvoJ8kFnKDyRKuNCvtnoBX7XvJl7iYmp4FvQfgSWFOkIIvWdGPbByMff6vYrXU3WvkGPLErZuM9ivj7HCwx55xiBimKZCiUgrTPrbgN4KJfcnA9YbgumoF9K4xdvQmBLxV5S/LIm7pUJS5+PSyZM+PNfsbuapYPQWfdTH5/ZGetdUNgV0=
-  file: $TRAVIS_BUILD_DIR/BambooTracker-$TRAVIS_TAG-macOS.zip
+  file: $TRAVIS_BUILD_DIR/BambooTracker-$TRAVIS_TAG-$TARGET_OS.zip
   skip_cleanup: true
   on:
     repo: rerrahkr/BambooTracker
     tags: true
-    condition: $TRAVIS_OS_NAME = osx
+    condition: $TRAVIS_OS_NAME != linux

--- a/ci/fetch_mingw.sh
+++ b/ci/fetch_mingw.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ "$#" -lt 2 ]]; then
+  echo "Incomplete list of arguments." >&2
+  echo "Need: <target-dir> <target-version>" >&2
+  exit 1
+fi
+
+MINGW_TARGETDIR="$1"
+MINGW_TARGETVER="$2"
+
+echo "Test if fetching MinGW freshly is required."
+
+if [[ -d "$MINGW_TARGETDIR"/bin && $("$MINGW_TARGETDIR"/bin/g++ -dumpversion) == "$MINGW_TARGETVER" ]]; then
+  echo "MinGW seems cached."
+  echo "If cache is incorrect, please delete the cache and restart the build."
+  exit 0
+else
+  echo "Uninstalling currently installed MinGW."
+  choco uninstall -y mingw
+  echo "Fetching requested x86 version of MinGW."
+  choco install -q mingw --version="$MINGW_TARGETVER" -x86 -params "/exception:dwarf"
+  echo "MinGW fetched."
+  exit 0
+fi
+

--- a/ci/fetch_qt.sh
+++ b/ci/fetch_qt.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ "$#" -lt 4 ]]; then
+  echo "Incomplete list of arguments." >&2
+  echo "Need: <target-dir> <target-version> <target-toolchain> <target-component> [<target-component>...]" >&2
+  exit 1
+fi
+
+QT_TARGETDIR="$1"
+QT_TARGETVER="$2"
+QT_TARGETTCH="$3"
+
+shift 3
+QT_TARGETCMP="$@"
+
+echo "Test if fetching Qt freshly is required."
+
+if [[ -d "$QT_TARGETDIR"/"$QT_TARGETVER" ]]; then
+  echo "Qt seems cached."
+  echo "If cache is incorrect, please delete the cache and restart the build."
+  exit 0
+else
+  curl https://code.qt.io/cgit/qbs/qbs.git/plain/scripts/install-qt.sh > install-qt.sh
+  bash ./install-qt.sh -d "$QT_TARGETDIR" --host "windows_x86" --version "$QT_TARGETVER" --toolchain "$QT_TARGETTCH" $QT_TARGETCMP
+  echo "Qt fetched."
+  if [[ "$(echo "$QT_TARGETCMP" | grep essentials 2>&1 >/dev/null; echo $?)" -eq 0 ]]; then
+    echo "Older Qt version detected, manually patching setup."
+    export QTPATH="$(echo "$QT_TARGETDIR"/"$QT_TARGETVER"/*)"
+    cat >"$QTPATH"/bin/qt.conf <<EOF
+[Paths]
+Prefix = ..
+EOF
+    sed -i -e 's/Enterprise/OpenSource/g' -e 's/licheck.*//g' "$QTPATH"/mkspecs/qconfig.pri
+    echo "Qt patched."
+  fi
+  exit 0
+fi
+

--- a/ci/package_osx.sh
+++ b/ci/package_osx.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+cp -a "$(find ../ -name BambooTracker.app)" ../{img,demos,licenses,specs,skins,*.md,LICENSE} .
+macdeployqt BambooTracker.app -verbose=2
+mv ../BambooTracker/.qm/ BambooTracker.app/Contents/Resources/lang
+
+exit 0

--- a/ci/package_windows.sh
+++ b/ci/package_windows.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+cp -a "$(find ../ -name BambooTracker.exe)" ../{img,demos,licenses,specs,skins,*.md,LICENSE} .
+windeployqt BambooTracker.exe -verbose=2
+mv translations lang
+mv ../BambooTracker/.qm/*.qm lang/
+
+exit 0


### PR DESCRIPTION
I figured it'd help to handle all releases via (one) CI, so I spent afew days tinkering with Travis CI and came up with this.

This is still a draft, I plan to either replace the development builds on AppVeyor with Windows & macOS debug builds via GitHub Actions or expand on the AppVeyor configuration with a macOS one next - I haven't decided yet what'd make the most sense.
Additionally, during my testing, the Qt fetching part on the Windows builder sometimes fails due to the Qt downloads page seemingly having networking problems. I think caching the fetched & configured Qt builds might help with working around such problems, though I have yet to dive into that.

Sharing this here for feedback & opinions, maybe help with the cache if anyone's feeling lucky.

The working Travis CI jobs + deployment, as of now, can be seen in action here:
https://travis-ci.com/github/OPNA2608/BambooTracker/builds/158645985

And releases page, to showcase the deployment here:
https://github.com/OPNA2608/BambooTracker/releases/tag/v0.4.2