### PR TITLE
Fix missing install target for translations

### DIFF
--- a/BambooTracker/BambooTracker.pro
+++ b/BambooTracker/BambooTracker.pro
@@ -443,13 +443,14 @@ include("stream/RtAudio/RtAudio.pri")
 include("midi/RtMidi/RtMidi.pri")
 
 equals(QT_MAJOR_VERSION, 5):lessThan(QT_MINOR_VERSION, 12) {
-    message(using a workaround for missing 'lrelease' option in Qt <5.12...)
+    message(Using a workaround for missing 'lrelease' option in Qt <5.12...)
 
     for(tsfile, TRANSLATIONS) {
       qmfile   = $$tsfile
       qmfile  ~= s/.ts$/.qm/
       qmfile  ~= s,^res/lang,.qm,
-               thisqmcom  = $${qmfile}.commands
+
+              thisqmcom  = $${qmfile}.commands
       win32:$$thisqmcom  = mkdir .qm;
        else:$$thisqmcom  = test -d .qm || mkdir -p .qm;
             $$thisqmcom += lrelease -qm $$qmfile $$PWD/$$tsfile
@@ -477,6 +478,10 @@ equals(QT_MAJOR_VERSION, 5):lessThan(QT_MINOR_VERSION, 12) {
     }
 }
 else {
+    !versionAtLeast(QT_VERSION, 5.14.2) {
+      message(Using a workaround for 'qm_files' target missing its install phase due to checking for the translations too early...)
+      qm_files.CONFIG = no_check_exist
+    }
     CONFIG += lrelease
 }
 


### PR DESCRIPTION
See QTBUG-77398, https://bugreports.qt.io/browse/QTBUG-77398. Affects
any Qt5 version from 5.12 to 5.14.1, which some Linux distros still use.

Before, without any .qm files in `BambooTracker/.qm` while invoking `qmake`:
![install_qms_before](https://user-images.githubusercontent.com/23431373/79118151-4fbf0180-7d8d-11ea-860f-994f03392f17.png)

After:
![install_qms_after](https://user-images.githubusercontent.com/23431373/79118165-577ea600-7d8d-11ea-9972-a62cbb84b7de.png)
