### PR TITLE
README adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,11 @@ To build BambooTracker, you'll need the following required dependencies:
 
 The way of acquiring all these will depend on your OS & distribution.
 
+#### Windows
+**TODO**
+- MinGW / MSVC
+- Qt5
+
 #### macOS
 You'll most likely need to install the Xcode Command Line Tools - how to acquire these might depend on your macOS version.
 
@@ -355,7 +360,7 @@ The following optional dependency exists:
 You should usually be able to install all required dependencies through your distribution's package manager.
 
 To build BambooTracker, you'll additionally need:
-- ALSA libraries
+- ALSA headers & libraries
 
 The following optional dependencies exist:
 - **PulseAudio Support**: PulseAudio headers & libraries
@@ -374,27 +379,31 @@ apt install \
 You may skip to "Compilation" - "Linux / BSD" - "FreeBSD" if you want to build via FreeBSD ports.
 
 ### Compilation
-Generally, this is how you build BambooTracker:
+Generally, BambooTracker releases are built like this:
 ```bash
 git clone https://github.com/rerrahkr/BambooTracker
 cd BambooTracker
-qmake CONFIG+=release
+qmake CONFIG-=debug CONFIG+=release
 make
-# For optionally installing into the system:
-make install
 ```
+
+#### Windows
+**TODO**
+- if using MinGW, `mingw32-make` / `mingw64-make` instead of make
+- if using MSVC *?*
+- prolly buildable more comfortably/windows-y via Qt Creator?
 
 #### macOS
 If you installed JACK via Homebrew, You might have to manually tell `qmake` where to find the JACK libraries & includes by appending the following:
 `LIBS+=-L/usr/local/opt/jack/lib INCLUDEPATH+=/usr/local/opt/jack/include`
 
-If you want to build with JACK support, append the following option to `qmake`:
+If you want to build with **JACK Support**, append the following option to `qmake`:
 `DEFINES+=__UNIX_JACK__`
 
 #### Linux / BSD
 If you want to build with any of the optional dependencies, append the following options to `qmake`:
-- PulseAudio: `DEFINES+=__LINUX_PULSE__`
-- JACK: `DEFINES+=__LINUX_PULSE__`
+- **PulseAudio Support**: `DEFINES+=__LINUX_PULSE__`
+- **JACK Support**: `DEFINES+=__UNIX_JACK__`
 
 ##### FreeBSD
 BambooTracker can be built via FreeBSD ports instead:
@@ -402,6 +411,14 @@ BambooTracker can be built via FreeBSD ports instead:
 cd /usr/ports/audio/bambootracker
 make install clean
 ```
+
+### Installing
+The base files (executable + i18n) can be installed into your system like this:
+```bash
+make install
+```
+
+For miscellaneous files like the example demos, skins, license informations etc, you'll have to copy them to the appropriate directories yourself.
 
 ## Changelog
 *See [CHANGELOG.md](./CHANGELOG.md).*

--- a/README.md
+++ b/README.md
@@ -325,53 +325,62 @@ BambooTracker supports following languages:
 - French
 - Japanese
 
-## Build on Linux
-On Ubuntu 18.04:
+## Build on Linux / BSD
 
-### Dependencies
-> make  
-> Qt5 (including qmake)  
-> Qt5 Multimedia  
-> Qt5 Multimedia plugins  
-> libasound2
+### Debian / Ubuntu
+`apt install bambootracker`
 
+### FreeBSD
+`pkg install bambootracker`
+
+### Manual
+#### Dependencies
+To build BambooTracker, you'll need the following required dependencies:
+- A C++ compiler (GCC/Clang/...)
+- make 
+- Qt5 Base
+- Qt5 Multimedia
+- Qt5 Multimedia plugins
+- Qt5 Tools (qmake, lrelease etc)
+- ALSA libraries
+
+There are some optional dependencies:
+- PulseAudio libraries
+  for PulseAudio support
+- JACK libraries
+  for JACK support
+
+The way of acquiring all these will depend on your distribution.
+
+##### Debian / Ubuntu:
 ```bash
-sudo apt-get install \
+apt install \
   build-essential \
-  qt5-default qtmultimedia5-dev libqt5multimedia5-plugins \
-  libasound2-dev
+  qt5-default qtmultimedia5-dev libqt5multimedia5-plugins qttools5-dev-tools \
+  libasound2-dev \
+  libpulse-dev libjack-dev
 ```
 
-You also need to install `libpulse-dev` if you use PulseAudio, or `libjack-dev`  if you use Jack.
-
-### Compilation
+#### Compilation
 ```bash
+git clone https://github.com/rerrahkr/BambooTracker
 cd BambooTracker
-qmake
+qmake CONFIG+=release
 make
+# For optionally installing into the system:
+make install
 ```
 
-If you use PulseAudio or JACK, add the option to `qmake`:
+If you want to build with PulseAudio or JACK support, append the following options to `qmake`:
 
-- PulseAudio: `qmake DEFINES+=__LINUX_PULSE__`
-- JACK: `qmake DEFINES+=__UNIX_JACK__`
+- PulseAudio: `DEFINES+=__LINUX_PULSE__`
+- JACK: `DEFINES+=__UNIX_JACK__`
 
-## Install package or build on FreeBSD
-### Build
-To build the BambooTracker via FreeBSD ports
+##### FreeBSD
 ```bash
 cd /usr/ports/audio/bambootracker
 make install clean
 ```
-
-### Package
-To install the package
-```bash
-pkg install bambootracker
-```
-
-## Install package on Debian or Ubuntu
-`apt-get install bambootracker`
 
 ## Changelog
 *See [CHANGELOG.md](./CHANGELOG.md).*

--- a/README.md
+++ b/README.md
@@ -12,18 +12,24 @@ BambooTracker is a music tracker for the Yamaha YM2608 (OPNA) sound chip which w
 [日本語](./README_ja.md)
 
 ## Downloads
-**On Windows**:
+### Windows
 
 - <https://github.com/rerrahkr/BambooTracker/releases>
 - *Development builds*: get "artifacts" from [Appveyor](https://ci.appveyor.com/project/rerrahkr/bambootracker)
 
-**On macOS**:
+### macOS
 
 - <https://github.com/rerrahkr/BambooTracker/releases>
 
-**On Linux**:
+### Linux / BSD
+#### Debian / Ubuntu
+`apt install bambootracker`
 
-- See below chapters "Build on Linux" - "Install package on Debian or Ubuntu".
+#### FreeBSD
+`pkg install bambootracker`
+
+#### Other
+- See chapter "Building"
 
 ## Wiki
 - [BambooTracker Wiki (GitHub Wiki)](https://github.com/rerrahkr/BambooTracker/wiki)
@@ -325,32 +331,35 @@ BambooTracker supports following languages:
 - French
 - Japanese
 
-## Build on Linux / BSD
-
-### Debian / Ubuntu
-`apt install bambootracker`
-
-### FreeBSD
-`pkg install bambootracker`
-
-### Manual
-#### Dependencies
+## Building
+### Dependencies
 To build BambooTracker, you'll need the following required dependencies:
 - A C++ compiler (GCC/Clang/...)
 - make 
 - Qt5 Base
 - Qt5 Multimedia
 - Qt5 Multimedia plugins
-- Qt5 Tools (qmake, lrelease etc)
+- Qt5 Tools (qmake, lrelease, ...)
+
+The way of acquiring all these will depend on your OS & distribution.
+
+#### macOS
+You'll most likely need to install the Xcode Command Line Tools - how to acquire these might depend on your macOS version.
+
+For Qt5, [check out Homebrew](https://formulae.brew.sh/formula/qt).
+
+The following optional dependency exists:
+- **JACK Support**: JACK headers & libraries (for example [through Homebrew](https://formulae.brew.sh/formula/jack))
+
+#### Linux / BSD
+You should usually be able to install all required dependencies through your distribution's package manager.
+
+To build BambooTracker, you'll additionally need:
 - ALSA libraries
 
-There are some optional dependencies:
-- PulseAudio libraries
-  for PulseAudio support
-- JACK libraries
-  for JACK support
-
-The way of acquiring all these will depend on your distribution.
+The following optional dependencies exist:
+- **PulseAudio Support**: PulseAudio headers & libraries
+- **JACK Support**: JACK headers & libraries
 
 ##### Debian / Ubuntu:
 ```bash
@@ -361,7 +370,11 @@ apt install \
   libpulse-dev libjack-dev
 ```
 
-#### Compilation
+##### FreeBSD
+You may skip to "Compilation" - "Linux / BSD" - "FreeBSD" if you want to build via FreeBSD ports.
+
+### Compilation
+Generally, this is how you build BambooTracker:
 ```bash
 git clone https://github.com/rerrahkr/BambooTracker
 cd BambooTracker
@@ -371,12 +384,20 @@ make
 make install
 ```
 
-If you want to build with PulseAudio or JACK support, append the following options to `qmake`:
+#### macOS
+If you installed JACK via Homebrew, You might have to manually tell `qmake` where to find the JACK libraries & includes by appending the following:
+`LIBS+=-L/usr/local/opt/jack/lib INCLUDEPATH+=/usr/local/opt/jack/include`
 
+If you want to build with JACK support, append the following option to `qmake`:
+`DEFINES+=__UNIX_JACK__`
+
+#### Linux / BSD
+If you want to build with any of the optional dependencies, append the following options to `qmake`:
 - PulseAudio: `DEFINES+=__LINUX_PULSE__`
-- JACK: `DEFINES+=__UNIX_JACK__`
+- JACK: `DEFINES+=__LINUX_PULSE__`
 
 ##### FreeBSD
+BambooTracker can be built via FreeBSD ports instead:
 ```bash
 cd /usr/ports/audio/bambootracker
 make install clean


### PR DESCRIPTION
Fixes #203.

---

I tried to expand on the whole Building section abit with more general information, with subsections for the different OS'/Distros. I can't say too much on the Windows & macOS sides of things, feel free to expand on those sections yourself & push to the branch or tell me what to put there. And the Japanese version of the README will need adjustments as well, I'd assume.

With the [Wiki](https://github.com/rerrahkr/BambooTracker/wiki) being available & less in-the-way, could we strip the READMEs of these sections and, if it hasn't been done yet, move all that information to the wiki btw? I think it'd increase the readability of the README quite abit.
- Glossary
- Interface Overview
- Key commands
- Volume range
- Effect list
- File I/O

Also, maybe some information in the README on how to contribute to BambooTracker would be good - i18n, skins, demo modules etc.