### PR TITLE
Compiler error: redefinition of `__RTMIDI_DUMMY__`

### DIFF
--- a/BambooTracker/BambooTracker.pro
+++ b/BambooTracker/BambooTracker.pro
@@ -62,7 +62,7 @@ else:if(gcc|clang) {
   }
   COMPILER_SPLIT_VERSION = $$split(COMPILER_VERSION, ".")
   COMPILER_MAJOR_VERSION = $$first(COMPILER_SPLIT_VERSION)
-  message("Compiler is version " $$COMPILER_VERSION)
+  message("Compiler is version" $$COMPILER_VERSION)
 
   # Temporary known-error downgrades
   clang {
@@ -71,6 +71,11 @@ else:if(gcc|clang) {
     # /usr/local/Cellar/jack/0.125.0_4/include/jack/types.h:(389,411)
     greaterThan(COMPILER_MAJOR_VERSION, 7) {
       CPPFLAGS += -Wno-error=deprecated-register
+    }
+    # FreeBSD ALSA headers use zero-length array
+    # /usr/local/include/alsa/pcm.h:597
+    freebsd {
+      CPPFLAGS += -Wno-zero-length-array
     }
   }
 }

--- a/BambooTracker/midi/RtMidi/RtMidi.cpp
+++ b/BambooTracker/midi/RtMidi/RtMidi.cpp
@@ -56,9 +56,7 @@
 //
 // **************************************************************** //
 
-#if !defined(__LINUX_ALSA__) && !defined(__UNIX_JACK__) && !defined(__MACOSX_CORE__) && !defined(__WINDOWS_MM__)
-  #define __RTMIDI_DUMMY__
-#endif
+#define __RTMIDI_DUMMY__
 
 #if defined(__MACOSX_CORE__)
 

--- a/BambooTracker/midi/RtMidi/RtMidi.pri
+++ b/BambooTracker/midi/RtMidi/RtMidi.pri
@@ -4,22 +4,14 @@ SOURCES += \
 HEADERS += \
     $$PWD/RtMidi.hpp
 
-linux {
-    use_jack {
-        DEFINES += __UNIX_JACK__
-        LIBS += -ljack
-        jack_has_rename {
-            DEFINES += JACK_HAS_PORT_RENAME
-        }
-    }
-    DEFINES += __LINUX_ALSA__
-    LIBS += -lasound
-}
 win32 {
     DEFINES += __WINDOWS_MM__
     LIBS += -lwinmm
 }
-macx {
+else:macx {
+    DEFINES += __MACOSX_CORE__
+    LIBS += -framework CoreMIDI -framework CoreAudio -framework CoreFoundation
+
     use_jack {
         DEFINES += __UNIX_JACK__
         LIBS += -ljack
@@ -27,8 +19,30 @@ macx {
             DEFINES += JACK_HAS_PORT_RENAME
         }
     }
-    DEFINES += __MACOSX_CORE__
-    LIBS += -framework CoreMIDI -framework CoreAudio -framework CoreFoundation
 }
+else:linux {
+    DEFINES += __LINUX_ALSA__
+    LIBS += -lasound
 
-DEFINES += __RTMIDI_DUMMY__
+    use_jack {
+        DEFINES += __UNIX_JACK__
+        LIBS += -ljack
+        jack_has_rename {
+            DEFINES += JACK_HAS_PORT_RENAME
+        }
+    }
+}
+else:bsd {
+    # OSS does not offer MIDI functionalities, only fallback to dummy interface
+    use_alsa {
+        DEFINES += __LINUX_ALSA__
+        LIBS += -lasound
+    }
+    use_jack {
+        DEFINES += __UNIX_JACK__
+        LIBS += -ljack
+        jack_has_rename {
+            DEFINES += JACK_HAS_PORT_RENAME
+        }
+    }
+}

--- a/BambooTracker/stream/RtAudio/RtAudio.pri
+++ b/BambooTracker/stream/RtAudio/RtAudio.pri
@@ -4,31 +4,51 @@ SOURCES += \
 HEADERS += \
     $$PWD/RtAudio.hpp
 
-linux {
-    use_pulse {
-        DEFINES += __LINUX_PULSE__
-        LIBS += -lpthread -lpulse-simple -lpulse
-    }
-    use_jack {
-        DEFINES += __UNIX_JACK__
-        LIBS += -ljack -lpthread
-    }
-    DEFINES += __LINUX_ALSA__
-    LIBS += -lasound -lpthread
-}
 win32 {
+    DEFINES += __WINDOWS_DS__
+    LIBS += -lole32 -lwinmm -ldsound -luser32
+
     greaterThan(QT_MAJOR_VERSION, 4):greaterThan(QT_MINOR_VERSION, 5) {
         DEFINES += __WINDOWS_WASAPI__
         LIBS += -lole32 -lwinmm -lksuser -lmfplat -lmfuuid -lwmcodecdspuuid
     }
-    DEFINES += __WINDOWS_DS__
-    LIBS += -lole32 -lwinmm -ldsound -luser32
 }
-macx {
-    use_jack {
-        DEFINES += __UNIX_JACK__
-        LIBS += -ljack -lpthread
-    }
+else:macx {
     DEFINES += __MACOSX_CORE__
     LIBS += -framework CoreAudio -framework CoreFoundation -lpthread
+
+    use_jack {
+        DEFINES += __UNIX_JACK__
+        LIBS += -ljack
+    }
+}
+else:linux {
+    DEFINES += __LINUX_ALSA__
+    LIBS += -lasound -lpthread
+
+    use_pulse {
+        DEFINES += __LINUX_PULSE__
+        LIBS += -lpulse-simple -lpulse
+    }
+    use_jack {
+        DEFINES += __UNIX_JACK__
+        LIBS += -ljack
+    }
+}
+else:bsd {
+    DEFINES += __LINUX_OSS__
+    LIBS += -lpthread
+
+    use_alsa {
+        DEFINES += __LINUX_ALSA__
+        LIBS += -lasound
+    }
+    use_pulse {
+        DEFINES += __LINUX_PULSE__
+        LIBS += -lpulse-simple -lpulse
+    }
+    use_jack {
+        DEFINES += __UNIX_JACK__
+        LIBS += -ljack
+    }
 }


### PR DESCRIPTION
`__RTMIDI_DUMMY__` gets defined in `BambooTracker/midi/RtMidi/RtMidi.pri` and `BambooTracker/midi/RtMidi/RtMidi.cpp` causing the following compiler warning:

```
/usr/local/lib/qt5/bin/moc -DQT_DEPRECATED_WARNINGS -D__RTMIDI_DUMMY__ -DQT_NO_DEBUG -DQT_MULTIMEDIA_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB --include /usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/moc_predefs.h -I/usr/local/lib/qt5/mkspecs/freebsd-clang -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/chips -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/stream -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/instrument -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/command -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/module -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/io -I/usr/local/include/qt5 -I/usr/local/include/qt5/QtMultimedia -I/usr/local/include/qt5/QtWidgets -I/usr/local/include/qt5/QtGui -I/usr/local/include/qt5/QtNetwork -I/usr/local/include/qt5/QtCore -I/usr/include/c++/v1 -I/usr/lib/clang/8.0.1/include -I/usr/include gui/instrument_selection_dialog.hpp -o moc_instrument_selection_dialog.cpp
--- RtMidi.o ---
midi/RtMidi/RtMidi.cpp:60:11: error: '__RTMIDI_DUMMY__' macro redefined [-Werror,-Wmacro-redefined]
  #define __RTMIDI_DUMMY__
          ^
<command line>:2:9: note: previous definition is here
#define __RTMIDI_DUMMY__ 1
        ^
--- moc_s98_export_settings_dialog.cpp ---
/usr/local/lib/qt5/bin/moc -DQT_DEPRECATED_WARNINGS -D__RTMIDI_DUMMY__ -DQT_NO_DEBUG -DQT_MULTIMEDIA_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB --include /usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/moc_predefs.h -I/usr/local/lib/qt5/mkspecs/freebsd-clang -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/chips -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/stream -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/instrument -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/command -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/module -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/io -I/usr/local/include/qt5 -I/usr/local/include/qt5/QtMultimedia -I/usr/local/include/qt5/QtWidgets -I/usr/local/include/qt5/QtGui -I/usr/local/include/qt5/QtNetwork -I/usr/local/include/qt5/QtCore -I/usr/include/c++/v1 -I/usr/lib/clang/8.0.1/include -I/usr/include gui/s98_export_settings_dialog.hpp -o moc_s98_export_settings_dialog.cpp
--- RtMidi.o ---
1 error generated.
--- moc_fm_envelope_set_edit_dialog.cpp ---
/usr/local/lib/qt5/bin/moc -DQT_DEPRECATED_WARNINGS -D__RTMIDI_DUMMY__ -DQT_NO_DEBUG -DQT_MULTIMEDIA_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB --include /usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/moc_predefs.h -I/usr/local/lib/qt5/mkspecs/freebsd-clang -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/chips -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/stream -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/instrument -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/command -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/module -I/usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker/io -I/usr/local/include/qt5 -I/usr/local/include/qt5/QtMultimedia -I/usr/local/include/qt5/QtWidgets -I/usr/local/include/qt5/QtGui -I/usr/local/include/qt5/QtNetwork -I/usr/local/include/qt5/QtCore -I/usr/include/c++/v1 -I/usr/lib/clang/8.0.1/include -I/usr/include gui/fm_envelope_set_edit_dialog.hpp -o moc_fm_envelope_set_edit_dialog.cpp
--- RtMidi.o ---
*** [RtMidi.o] Error code 1

make[1]: stopped in /usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker
1 error

make[1]: stopped in /usr/ports/audio/bambootracker/work/BambooTracker-0.4.3/BambooTracker
===> Compilation failed unexpectedly.
Try to set MAKE_JOBS_UNSAFE=yes and rebuild before reporting the failure to
the maintainer.
*** Error code 1

Stop.
make: stopped in /usr/ports/audio/bambootracker
```