### PR TITLE
Revert "Fix VLA warnings"

### DIFF
--- a/BambooTracker/BambooTracker.pro
+++ b/BambooTracker/BambooTracker.pro
@@ -65,7 +65,14 @@ else:if(gcc|clang) {
   message("Compiler is version " $$COMPILER_VERSION)
 
   # Temporary known-error downgrades
+
+  # RtAudio code contains VLAs for multiple APIs, needs a stronger patch in the future
+  CPPFLAGS += -Wno-error=vla
+
   clang {
+    # See VLA workaround, needs additional switch on Clang
+    CPPFLAGS += -Wno-vla-extension
+
     # macOS 10.14 (LLVM 11.0.0) targeting gnu++1y (C++14) errors when
     # using system-installed JACK headers in RtAudio & RtMidi
     # /usr/local/Cellar/jack/0.125.0_4/include/jack/types.h:(389,411)

--- a/BambooTracker/midi/RtMidi/RtMidi.cpp
+++ b/BambooTracker/midi/RtMidi/RtMidi.cpp
@@ -1360,7 +1360,7 @@ void MidiOutCore :: sendMessage( const unsigned char *message, size_t size )
     return;
   }
 
-  Byte* buffer = new Byte[nBytes+(sizeof(MIDIPacketList))];
+  Byte buffer[nBytes+(sizeof(MIDIPacketList))];
   ByteCount listSize = sizeof(buffer);
   MIDIPacketList *packetList = (MIDIPacketList*)buffer;
   MIDIPacket *packet = MIDIPacketListInit( packetList );

--- a/BambooTracker/stream/RtAudio/RtAudio.cpp
+++ b/BambooTracker/stream/RtAudio/RtAudio.cpp
@@ -607,25 +607,20 @@ unsigned int RtApiCore :: getDefaultInputDevice( void )
   }
 
   dataSize *= nDevices;
-  AudioDeviceID *deviceList = new AudioDeviceID[ nDevices ];
+  AudioDeviceID deviceList[ nDevices ];
   property.mSelector = kAudioHardwarePropertyDevices;
   result = AudioObjectGetPropertyData( kAudioObjectSystemObject, &property, 0, NULL, &dataSize, (void *) &deviceList );
   if ( result != noErr ) {
     errorText_ = "RtApiCore::getDefaultInputDevice: OS-X system error getting device IDs.";
     error( RtAudioError::WARNING );
-    delete[] deviceList;
     return 0;
   }
 
   for ( unsigned int i=0; i<nDevices; i++ )
-    if ( id == deviceList[i] ) {
-      delete[] deviceList;
-      return i;
-    }
+    if ( id == deviceList[i] ) return i;
 
   errorText_ = "RtApiCore::getDefaultInputDevice: No default device found!";
   error( RtAudioError::WARNING );
-  delete[] deviceList;
   return 0;
 }
 
@@ -645,25 +640,20 @@ unsigned int RtApiCore :: getDefaultOutputDevice( void )
   }
 
   dataSize = sizeof( AudioDeviceID ) * nDevices;
-  AudioDeviceID *deviceList = new AudioDeviceID[ nDevices ];
+  AudioDeviceID deviceList[ nDevices ];
   property.mSelector = kAudioHardwarePropertyDevices;
   result = AudioObjectGetPropertyData( kAudioObjectSystemObject, &property, 0, NULL, &dataSize, (void *) &deviceList );
   if ( result != noErr ) {
     errorText_ = "RtApiCore::getDefaultOutputDevice: OS-X system error getting device IDs.";
     error( RtAudioError::WARNING );
-    delete[] deviceList;
     return 0;
   }
 
   for ( unsigned int i=0; i<nDevices; i++ )
-    if ( id == deviceList[i] ) {
-      delete[] deviceList;
-      return i;
-    }
+    if ( id == deviceList[i] ) return i;
 
   errorText_ = "RtApiCore::getDefaultOutputDevice: No default device found!";
   error( RtAudioError::WARNING );
-  delete[] deviceList;
   return 0;
 }
 
@@ -686,7 +676,7 @@ RtAudio::DeviceInfo RtApiCore :: getDeviceInfo( unsigned int device )
     return info;
   }
 
-  AudioDeviceID *deviceList = new AudioDeviceID[ nDevices ];
+  AudioDeviceID deviceList[ nDevices ];
   UInt32 dataSize = sizeof( AudioDeviceID ) * nDevices;
   AudioObjectPropertyAddress property = { kAudioHardwarePropertyDevices,
                                           kAudioObjectPropertyScopeGlobal,
@@ -696,12 +686,10 @@ RtAudio::DeviceInfo RtApiCore :: getDeviceInfo( unsigned int device )
   if ( result != noErr ) {
     errorText_ = "RtApiCore::getDeviceInfo: OS-X system error getting device IDs.";
     error( RtAudioError::WARNING );
-    delete[] deviceList;
     return info;
   }
 
   AudioDeviceID id = deviceList[ device ];
-  delete[] deviceList;
 
   // Get the device name.
   info.name.erase();
@@ -840,13 +828,12 @@ RtAudio::DeviceInfo RtApiCore :: getDeviceInfo( unsigned int device )
   }
 
   UInt32 nRanges = dataSize / sizeof( AudioValueRange );
-  AudioValueRange *rangeList = new AudioValueRange[ nRanges ];
+  AudioValueRange rangeList[ nRanges ];
   result = AudioObjectGetPropertyData( id, &property, 0, NULL, &dataSize, &rangeList );
   if ( result != kAudioHardwareNoError ) {
     errorStream_ << "RtApiCore::getDeviceInfo: system error (" << getErrorCode( result ) << ") getting sample rates.";
     errorText_ = errorStream_.str();
     error( RtAudioError::WARNING );
-    delete[] rangeList;
     return info;
   }
 
@@ -874,7 +861,6 @@ RtAudio::DeviceInfo RtApiCore :: getDeviceInfo( unsigned int device )
       if ( rangeList[i].mMaximum < maximumRate ) maximumRate = rangeList[i].mMaximum;
     }
   }
-  delete[] rangeList;
 
   if ( haveValueRange ) {
     for ( unsigned int k=0; k<MAX_SAMPLE_RATES; k++ ) {
@@ -980,7 +966,7 @@ bool RtApiCore :: probeDeviceOpen( unsigned int device, StreamMode mode, unsigne
     return FAILURE;
   }
 
-  AudioDeviceID *deviceList = new AudioDeviceID[ nDevices ];
+  AudioDeviceID deviceList[ nDevices ];
   UInt32 dataSize = sizeof( AudioDeviceID ) * nDevices;
   AudioObjectPropertyAddress property = { kAudioHardwarePropertyDevices,
                                           kAudioObjectPropertyScopeGlobal,
@@ -993,7 +979,6 @@ bool RtApiCore :: probeDeviceOpen( unsigned int device, StreamMode mode, unsigne
   }
 
   AudioDeviceID id = deviceList[ device ];
-  delete[] deviceList;
 
   // Setup for stream mode.
   bool isInput = false;
@@ -8300,12 +8285,11 @@ void RtApiAlsa :: callbackEvent()
     if ( stream_.deviceInterleaved[1] )
       result = snd_pcm_readi( handle[1], buffer, stream_.bufferSize );
     else {
-      void **bufs = new void*[channels];
+      void *bufs[channels];
       size_t offset = stream_.bufferSize * formatBytes( format );
       for ( int i=0; i<channels; i++ )
         bufs[i] = (void *) (buffer + (i * offset));
       result = snd_pcm_readn( handle[1], bufs, stream_.bufferSize );
-      delete[] bufs;
     }
 
     if ( result < (int) stream_.bufferSize ) {
@@ -8371,12 +8355,11 @@ void RtApiAlsa :: callbackEvent()
     if ( stream_.deviceInterleaved[0] )
       result = snd_pcm_writei( handle[0], buffer, stream_.bufferSize );
     else {
-      void **bufs = new void*[channels];
+      void *bufs[channels];
       size_t offset = stream_.bufferSize * formatBytes( format );
       for ( int i=0; i<channels; i++ )
         bufs[i] = (void *) (buffer + (i * offset));
       result = snd_pcm_writen( handle[0], bufs, stream_.bufferSize );
-      delete[] bufs;
     }
 
     if ( result < (int) stream_.bufferSize ) {

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ BambooTracker is a music tracker for the Yamaha YM2608 (OPNA) sound chip which w
 
 ## Downloads
 ### Windows / macOS
+***macOS: Due to issue https://github.com/rerrahkr/BambooTracker/issues/231, the v0.4.3 macOS builds are broken. Until a new release is pushed, please use a development build instead!***
+
 - <https://github.com/rerrahkr/BambooTracker/releases>
 - *Development builds*: get "artifacts" from [Appveyor](https://ci.appveyor.com/project/rerrahkr/bambootracker)
 


### PR DESCRIPTION
This reverts commit 149523abb87973602452e83860d78aba90903d54.

Fix for https://github.com/rerrahkr/BambooTracker/issues/231.

Additionally, re-adds VLA workaround switch to CPPFLAGS & warns about
broken macOS release build in README.md.