### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Report a bug in/around BambooTracker
+title: "[Windows|macOS|Linux|BSD] - Short bug summary"
+labels: bug
+assignees: ''
+
+---
+
+> #### Checklist
+> 
+> <!-- You don't have to fill these out, but it would help us alot with managing open bug reports if you make sure to check these things first! -->
+> 
+> - [ ] I am reporting exactly 1 bug with this issue.
+> - [ ] This bug hasn't already been reported.
+> - [ ] This bug hasn't already been fixed in the latest development build.
+
+---
+
+## Bug Description
+
+<!-- Please explain the bug/problem you're experiencing here, with as many details/pictures as you think are necessary to get your situation across. -->
+
+## How to reproduce
+
+<!-- If applicable, give a step-by-step guide on how to reproduce your bug. If you encounter problems with any files in particular, please attach them. -->
+
+1. …
+2. …
+3. …
+
+## System Information
+
+<!-- Please fill out these details about your system, to help us debug your problem. -->
+
+- **Operating System**: <!-- OS/Distro name and version -->
+- **BambooTracker Version**: <!-- release version or "unstable-(commitID)", e.g. v0.4.3 or unstable-61874f31 -->
+- **Build Type**: <!-- "Official" if binary was downloaded from release or development build page, else clarify how it was built (e.g. locally or via a package manager). -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: Suggest a feature / QOL improvement
+title: "[Feature] - Short feature summary"
+labels: enhancement
+assignees: ''
+
+---
+
+> #### Checklist
+> 
+> <!-- You don't have to fill these out, but it would help us alot with managing open feature requests if you make sure to check these things first! -->
+> 
+> - [ ] I'm requesting exactly 1 feature with this issue.
+> - [ ] This feature hasn't already been requested.
+> - [ ] This feature hasn't already been implemented in the latest development build.
+
+---
+
+## Requested Feature
+
+<!-- Please explain the feature you'd like to see here, however you'd like, with as many details as you think are necessary to get your idea across. No further form requirements from here on out. -->


### PR DESCRIPTION
Adds some basic templates for issues: a bug report and a feature request. These will automatically add the bug/enhancement labels based on the used template, and hopefully result in more helpful/detailed bug reports. (see #224)

Whether doing a PR template would be useful or not and how that should look, I'll leave up to you.

PS: I saw you were trying to skip a CI build recently with 61874f3100259a84d25c3b949c0304b93e7f6348, AppVeyor requires that "[ci skip]" appears in the message *title*.