### PR TITLE
Audio stream initialization by multiple APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 - [#266] - Set a license to a part of the source code (thanks [@superctr])
+- Try to initialize audio stream by multiple APIs on the first launch ([#270]; thanks [@N-SPC700], [@OPNA2608])
 
 ### Fixed
 - [#256] - Fix a crash bug on launch when maximized (thanks [@nyanpasu64])
@@ -20,6 +21,7 @@
 - Fix `0Xxx`, `0Yxx` and `0Zxx` to work
 - [#267] - Fix a crash when changing the current song type (thanks [@Zexxerd])
 - [#269] - Fix order insert when changing the pattern size to less than 64 (thanks [@Toonlink8101])
+- [#272] - Fix FM3ch expanded labeling and muting bug when changing the song type (thanks [@Toonlink8101])
 
 [@Yuzu4K]: https://twitter.com/Yuzu4K
 [@Zexxerd]: https://github.com/Zexxerd
@@ -35,6 +37,8 @@
 [#266]: https://github.com/rerrahkr/BambooTracker/issues/266
 [#267]: https://github.com/rerrahkr/BambooTracker/issues/267
 [#269]: https://github.com/rerrahkr/BambooTracker/issues/269
+[#270]: https://github.com/rerrahkr/BambooTracker/issues/270
+[#272]: https://github.com/rerrahkr/BambooTracker/issues/272
 
 ## v0.4.4 (2020-08-22)
 ### Added


### PR DESCRIPTION
Close #270

I cannot test in my macOS, which is borrowed from my friend, because I cannot install JACK to it.

@N-SPC700 Could you please check that this works well?

@OPNA2608 This PR will only try to initialize with multiple APIs the first time it starts, strictly speaking, when no APIs are specified in the configuration file. The available API is automatically selected at the first startup, but if an error like  [your report](https://github.com/rerrahkr/BambooTracker/issues/270#issuecomment-713639218) occurs at the second and subsequent launches, it is considered that the cause is the user's operation, so the tracker will suggest that the user manually change the API settings.