### PR TITLE
Synchronize sample rate between the emulation and the audio stream

### DIFF
--- a/BambooTracker/gui/mainwindow.hpp
+++ b/BambooTracker/gui/mainwindow.hpp
@@ -249,6 +249,14 @@ private:
 							  QMessageBox::Ok, QMessageBox::Ok);
 	}
 
+	inline void showStreamRateWarningDialog(uint32_t curRate)
+	{
+		QMessageBox::warning(this, tr("Warning"),
+							 tr("Could not set the sample rate of the audio stream to %1Hz. Currently the stream runs on %2Hz instead.")
+							 .arg(config_.lock()->getSampleRate()).arg(curRate),
+							 QMessageBox::Ok, QMessageBox::Ok);
+	}
+
 	inline void showMidiFailedDialog(const QString& errDetail)
 	{
 		QMessageBox::critical(this, tr("Error"),

--- a/BambooTracker/stream/audio_stream.cpp
+++ b/BambooTracker/stream/audio_stream.cpp
@@ -85,6 +85,11 @@ void AudioStream::setInterruption(uint32_t intrRate)
 	intrCount_ = rate_ / intrRate_;
 }
 
+uint32_t AudioStream::getStreamRate() const
+{
+	return rate_;
+}
+
 void AudioStream::start()
 {
 	std::lock_guard<std::mutex> lock(mutex_);

--- a/BambooTracker/stream/audio_stream.hpp
+++ b/BambooTracker/stream/audio_stream.hpp
@@ -62,6 +62,7 @@ public:
 	virtual QString getDefaultOutputDevice(const QString& backend) const = 0;
 
 	void setInterruption(uint32_t inrtRate);
+	uint32_t getStreamRate() const;
 
 	virtual void start();
 	virtual void stop();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [#269] - Fix order insert when changing the pattern size to less than 64 (thanks [@Toonlink8101])
 - [#272] - Fix FM3ch expanded labeling and muting bug when changing the song type (thanks [@Toonlink8101])
 - [#277] - Wait pattern drawing until initializing internal data ([#276]; thanks [@OPNA2608])
+- [#279] - Synchronize sample rate between the emulation and the audio stream (thanks [@OPNA2608])
 
 [@Yuzu4K]: https://twitter.com/Yuzu4K
 [@Zexxerd]: https://github.com/Zexxerd
@@ -49,6 +50,7 @@
 [#276]: https://github.com/rerrahkr/BambooTracker/issues/276
 [#277]: https://github.com/rerrahkr/BambooTracker/pull/277
 [#278]: https://github.com/rerrahkr/BambooTracker/issues/278
+[#279]: https://github.com/rerrahkr/BambooTracker/issues/279
 
 ## v0.4.4 (2020-08-22)
 ### Added


### PR DESCRIPTION
close #279 

Check the sample rate between the configuration and ALSA.
If they are different, the emulation sample rate is changed and show warning.

@OPNA2608  Could you please check this PR works well? I cannot test about ALSA on Windows.