### PR TITLE
Revert "Fix .vgi import to load the operator 2 and 3 correctly"

### DIFF
--- a/BambooTracker/io/instrument_io.cpp
+++ b/BambooTracker/io/instrument_io.cpp
@@ -2908,20 +2908,6 @@ AbstractInstrument* InstrumentIO::loadVGIFile(const BinaryContainer& ctr, std::s
 	ssgeg1 = ssgeg1 & 8 ? ssgeg1 & 7 : -1;
 	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::SSGEG1, ssgeg1);
 
-	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::ML2, ctr.readUint8(csr++));
-	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::DT2, convertDTInTFIVGIDMP(ctr.readUint8(csr++)));
-	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::TL2, ctr.readUint8(csr++));
-	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::KS2, ctr.readUint8(csr++));
-	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::AR2, ctr.readUint8(csr++));
-	uint8_t drams2 = ctr.readUint8(csr++);
-	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::DR2, drams2 & 31);
-	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::SR2, ctr.readUint8(csr++));
-	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::RR2, ctr.readUint8(csr++));
-	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::SL2, ctr.readUint8(csr++));
-	int ssgeg2 = ctr.readUint8(csr++);
-	ssgeg2 = ssgeg2 & 8 ? ssgeg2 & 7 : -1;
-	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::SSGEG2, ssgeg2);
-
 	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::ML3, ctr.readUint8(csr++));
 	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::DT3, convertDTInTFIVGIDMP(ctr.readUint8(csr++)));
 	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::TL3, ctr.readUint8(csr++));
@@ -2935,6 +2921,20 @@ AbstractInstrument* InstrumentIO::loadVGIFile(const BinaryContainer& ctr, std::s
 	int ssgeg3 = ctr.readUint8(csr++);
 	ssgeg3 = ssgeg3 & 8 ? ssgeg1 & 7 : -1;
 	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::SSGEG3, ssgeg3);
+
+	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::ML2, ctr.readUint8(csr++));
+	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::DT2, convertDTInTFIVGIDMP(ctr.readUint8(csr++)));
+	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::TL2, ctr.readUint8(csr++));
+	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::KS2, ctr.readUint8(csr++));
+	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::AR2, ctr.readUint8(csr++));
+	uint8_t drams2 = ctr.readUint8(csr++);
+	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::DR2, drams2 & 31);
+	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::SR2, ctr.readUint8(csr++));
+	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::RR2, ctr.readUint8(csr++));
+	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::SL2, ctr.readUint8(csr++));
+	int ssgeg2 = ctr.readUint8(csr++);
+	ssgeg2 = ssgeg2 & 8 ? ssgeg2 & 7 : -1;
+	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::SSGEG2, ssgeg2);
 
 	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::ML4, ctr.readUint8(csr++));
 	instManLocked->setEnvelopeFMParameter(envIdx, FMEnvelopeParameter::DT4, convertDTInTFIVGIDMP(ctr.readUint8(csr++)));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 - [#284] - Fix the bug locking paint events after opening non-existent module (thanks [@OPNA2608])
+- Fixed incorrect fix of VGI order of operators (thanks [@OPNA2608])
 
 [#285]: https://github.com/rerrahkr/BambooTracker/pull/285
 [#284]: https://github.com/rerrahkr/BambooTracker/issues/284


### PR DESCRIPTION
This reverts commit 8e7879fd9dcc66a16135c639747dea7a7209ccb7. The "incorrect" operator order is actually correct. Chip-internal order of values is 0->2->1->3, VGI stores the values in the order 0->1->2->3 just like TFI (which was unaffected by the reverted commit). See [VGI File Format](https://vgmrips.net/wiki/VGI_File_Format) and [TFI File Format](https://vgmrips.net/wiki/TFI_File_Format).