### PR TITLE
Fix macOS GHA

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -63,7 +63,7 @@ jobs:
           brew unlink python@3.9
           brew link --overwrite python@3.9
           brew upgrade --force python@3.9
-          brew install qt5 pkg-config jack p7zip
+          brew install qt5 pkg-config jack
           brew link --force qt5
 
       ## End macOS-specific steps


### PR DESCRIPTION
GitHub CI complains about p7zip already being installed but outdated. We don't depend on the latest p7zip so the pre-installed one will be fine.