### PR TITLE
Qt6 support & building

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,7 +37,7 @@ environment:
       COMPILER: C:\Qt\Tools\mingw530_32\bin
       QT: C:\Qt\5.10.1\mingw53_32\bin
       PLATFORM: windows
-      DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-dev-windows.zip
+      DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-dev-windows-x86.zip
       MAKE: mingw32-make
       RELEASE_BUILD: false
     # Windows XP (Debug)
@@ -46,7 +46,7 @@ environment:
       COMPILER: C:\Qt\Tools\mingw492_32\bin
       QT: C:\Qt\5.5\mingw492_32\bin
       PLATFORM: windows-xp
-      DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-dev-windows-xp.zip
+      DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-dev-windows-xp-x86.zip
       MAKE: mingw32-make
       RELEASE_BUILD: false
     # Windows XP (Release)
@@ -55,13 +55,13 @@ environment:
       COMPILER: C:\Qt\Tools\mingw492_32\bin
       QT: C:\Qt\5.5\mingw492_32\bin
       PLATFORM: windows-xp
-      DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-windows-xp.zip
+      DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-windows-xp-x86.zip
       MAKE: mingw32-make
       RELEASE_BUILD: true
     - APPVEYOR_JOB_NAME: for macOS
       APPVEYOR_BUILD_WORKER_IMAGE: macOS-Mojave
       PLATFORM: macos
-      DEST: BambooTracker-v$APPVEYOR_BUILD_VERSION-dev-macos.zip
+      DEST: BambooTracker-v$APPVEYOR_BUILD_VERSION-dev-macos-x86_64.zip
       MAKE: make
       RELEASE_BUILD: false
 
@@ -96,7 +96,7 @@ before_build:
   - ps: $env:Path = "$env:QT;$env:COMPILER;$env:Path"
   - sh: |
       brew install qt5 pkg-config jack p7zip
-      export PATH="/usr/local/opt/qt/bin:$PATH"
+      export PATH="/usr/local/opt/qt@5/bin:$PATH"
       export PKG_CONFIG_PATH="/usr/local/opt/jack/lib/pkgconfig"${PKG_CONFIG_PATH:+':'}$PKG_CONFIG_PATH
 
 # to run your custom scripts instead of automatic MSBuild
@@ -119,7 +119,7 @@ after_build:
   - cd target
   # Port of scripts/package_windows.sh to PowerShell
   - ps: |
-      Copy-Item -Recurse ..\img,..\*.md .
+      Copy-Item -Recurse ..\*.md .
       $HELP_OUT = (windeployqt.exe -h)
       $DEPLOY_OPTS = "-verbose=2"
       $PLUGIN_OPTS = @("--no-quick-import","--no-system-d3d-compiler","--no-webkit2","--no-opengl-sw","--no-virtualkeyboard","--no-angle")

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -95,7 +95,7 @@ platform: x86
 before_build:
   - ps: $env:Path = "$env:QT;$env:COMPILER;$env:Path"
   - sh: |
-      brew install qt pkg-config jack p7zip
+      brew install qt5 pkg-config jack p7zip
       export PATH="/usr/local/opt/qt/bin:$PATH"
       export PKG_CONFIG_PATH="/usr/local/opt/jack/lib/pkgconfig"${PKG_CONFIG_PATH:+':'}$PKG_CONFIG_PATH
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,7 +37,7 @@ environment:
       COMPILER: C:\Qt\Tools\mingw530_32\bin
       QT: C:\Qt\5.10.1\mingw53_32\bin
       PLATFORM: windows
-      DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-dev-windows-x86.zip
+      DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-dev-windows-7-32bit.zip
       MAKE: mingw32-make
       RELEASE_BUILD: false
     # Windows XP (Debug)
@@ -46,7 +46,7 @@ environment:
       COMPILER: C:\Qt\Tools\mingw492_32\bin
       QT: C:\Qt\5.5\mingw492_32\bin
       PLATFORM: windows-xp
-      DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-dev-windows-xp-x86.zip
+      DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-dev-windows-xp-32bit.zip
       MAKE: mingw32-make
       RELEASE_BUILD: false
     # Windows XP (Release)
@@ -55,13 +55,13 @@ environment:
       COMPILER: C:\Qt\Tools\mingw492_32\bin
       QT: C:\Qt\5.5\mingw492_32\bin
       PLATFORM: windows-xp
-      DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-windows-xp-x86.zip
+      DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-windows-xp-32bit.zip
       MAKE: mingw32-make
       RELEASE_BUILD: true
     - APPVEYOR_JOB_NAME: for macOS
       APPVEYOR_BUILD_WORKER_IMAGE: macOS-Mojave
       PLATFORM: macos
-      DEST: BambooTracker-v$APPVEYOR_BUILD_VERSION-dev-macos-x86_64.zip
+      DEST: BambooTracker-v$APPVEYOR_BUILD_VERSION-dev-macos-64bit.zip
       MAKE: make
       RELEASE_BUILD: false
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,7 +22,7 @@ defaults:
     shell: bash
 
 env:
-  BUILD_TARGET: macos
+  BUILD_TARGET: macos-x86_64
   SCRIPT_NAME: osx
   MAKE: make
   BT_INSTALLBASE: ${{ github.workspace }}/target/

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,7 +22,7 @@ defaults:
     shell: bash
 
 env:
-  BUILD_TARGET: macos-x86_64
+  BUILD_TARGET: macos-64bit
   SCRIPT_NAME: osx
   MAKE: make
   BT_INSTALLBASE: ${{ github.workspace }}/target/

--- a/.github/workflows/nixpkgs.yml
+++ b/.github/workflows/nixpkgs.yml
@@ -22,7 +22,7 @@ defaults:
     shell: bash
 
 env:
-  BUILD_TARGET: linux
+  BUILD_TARGET: linux-x86_64
   NIXPKGS_CHANNEL: nixos-20.09
   BT_INSTALLBASE: ${{ github.workspace }}/target/
 

--- a/.github/workflows/nixpkgs.yml
+++ b/.github/workflows/nixpkgs.yml
@@ -22,7 +22,7 @@ defaults:
     shell: bash
 
 env:
-  BUILD_TARGET: linux-x86_64
+  BUILD_TARGET: linux-64bit
   NIXPKGS_CHANNEL: nixos-20.09
   BT_INSTALLBASE: ${{ github.workspace }}/target/
 

--- a/.github/workflows/windows-10-qt6.yml
+++ b/.github/workflows/windows-10-qt6.yml
@@ -22,7 +22,7 @@ defaults:
     shell: bash
 
 env:
-  BUILD_TARGET: windows-10-x86_64-qt6
+  BUILD_TARGET: windows-10-x86_64
   MAKE: mingw32-make
   BT_INSTALLBASE: ${{ github.workspace }}/target/
   MINGW_VERSION: 8.1.0

--- a/.github/workflows/windows-10-qt6.yml
+++ b/.github/workflows/windows-10-qt6.yml
@@ -22,7 +22,7 @@ defaults:
     shell: bash
 
 env:
-  BUILD_TARGET: windows-10-x86_64
+  BUILD_TARGET: windows-10-64bit
   MAKE: mingw32-make
   BT_INSTALLBASE: ${{ github.workspace }}/target/
   MINGW_VERSION: 8.1.0

--- a/.github/workflows/windows-10-qt6.yml
+++ b/.github/workflows/windows-10-qt6.yml
@@ -29,7 +29,7 @@ env:
   MINGW_BITNESS: 64
   MINGW_CHOCOBASE: /c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64
   MINGW_INSTALLBASE: ${{ github.workspace }}/mingw64/
-  QT_VERSION: 6.1.0
+  QT_VERSION: 6.0.2
   QT_TOOLCHAIN: win64_mingw81
   QT_MODULES: qtbase qttools qttranslations qt5compat
   QT_INSTALLBASE: ${{ github.workspace }}/Qt/

--- a/.github/workflows/windows-10-qt6.yml
+++ b/.github/workflows/windows-10-qt6.yml
@@ -1,4 +1,4 @@
-name: Windows (7 and up, 32-bit, Qt5)
+name: Windows 10 (64-bit, Qt6)
 
 on:
   push:
@@ -22,16 +22,16 @@ defaults:
     shell: bash
 
 env:
-  BUILD_TARGET: windows
+  BUILD_TARGET: windows-10-x86_64-qt6
   MAKE: mingw32-make
   BT_INSTALLBASE: ${{ github.workspace }}/target/
   MINGW_VERSION: 8.1.0
-  MINGW_BITNESS: 32
-  MINGW_CHOCOBASE: /c/ProgramData/chocolatey/lib/mingw/tools/install/mingw32
-  MINGW_INSTALLBASE: ${{ github.workspace }}/mingw32/
-  QT_VERSION: 5.15.1
-  QT_TOOLCHAIN: win32_mingw81
-  QT_MODULES: qtbase qttools qttranslations
+  MINGW_BITNESS: 64
+  MINGW_CHOCOBASE: /c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64
+  MINGW_INSTALLBASE: ${{ github.workspace }}/mingw64/
+  QT_VERSION: 6.1.0
+  QT_TOOLCHAIN: win64_mingw81
+  QT_MODULES: qtbase qttools qttranslations qt5compat
   QT_INSTALLBASE: ${{ github.workspace }}/Qt/
 
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,4 @@
-name: Windows (7 and up, 32-bit, Qt5)
+name: Windows 7 and up (32-bit, Qt5)
 
 on:
   push:
@@ -22,7 +22,7 @@ defaults:
     shell: bash
 
 env:
-  BUILD_TARGET: windows
+  BUILD_TARGET: windows-x86
   MAKE: mingw32-make
   BT_INSTALLBASE: ${{ github.workspace }}/target/
   MINGW_VERSION: 8.1.0

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,7 @@ defaults:
     shell: bash
 
 env:
-  BUILD_TARGET: windows-x86
+  BUILD_TARGET: windows-7-32bit
   MAKE: mingw32-make
   BT_INSTALLBASE: ${{ github.workspace }}/target/
   MINGW_VERSION: 8.1.0

--- a/BambooTracker/BambooTracker.pro
+++ b/BambooTracker/BambooTracker.pro
@@ -7,6 +7,8 @@
 QT       += core gui
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+# Porting helper Qt5 -> Qt6
+greaterThan(QT_MAJOR_VERSION, 5): QT += core5compat
 
 TARGET = BambooTracker
 TEMPLATE = app
@@ -78,6 +80,11 @@ else:clang|if(gcc:!intel_icc) {
   message("Compiler is version" $$COMPILER_VERSION)
 
   # Temporary known-error downgrades here
+
+  # WIP Requires a deeper look into the warnings to make Qt5 -> Qt6 transition clean
+  greaterThan(QT_MAJOR_VERSION, 5) {
+    CPP_WARNING_FLAGS += -Wno-error=deprecated-declarations -Wno-error=unused-result
+  }
 }
 else {
   message("Configured compiler is unknown, no attempt to add warning & pedantic compiler switches")

--- a/BambooTracker/BambooTracker.pro
+++ b/BambooTracker/BambooTracker.pro
@@ -80,11 +80,6 @@ else:clang|if(gcc:!intel_icc) {
   message("Compiler is version" $$COMPILER_VERSION)
 
   # Temporary known-error downgrades here
-
-  # WIP Requires a deeper look into the warnings to make Qt5 -> Qt6 transition clean
-  greaterThan(QT_MAJOR_VERSION, 5) {
-    CPP_WARNING_FLAGS += -Wno-error=deprecated-declarations -Wno-error=unused-result
-  }
 }
 else {
   message("Configured compiler is unknown, no attempt to add warning & pedantic compiler switches")

--- a/BambooTracker/gui/bookmark_manager_form.cpp
+++ b/BambooTracker/gui/bookmark_manager_form.cpp
@@ -50,9 +50,9 @@ BookmarkManagerForm::BookmarkManagerForm(std::weak_ptr<BambooTracker> core, bool
 	QObject::connect(insSc_.get(), &QShortcut::activated, this, &BookmarkManagerForm::on_createPushButton_clicked);
 	delSc_ = std::make_unique<QShortcut>(Qt::Key_Delete, ui->listWidget, nullptr, nullptr, Qt::WidgetShortcut);
 	QObject::connect(delSc_.get(), &QShortcut::activated, this, &BookmarkManagerForm::on_removePushButton_clicked);
-	mvUpSc_ = std::make_unique<QShortcut>(Qt::CTRL + Qt::Key_Up, ui->listWidget, nullptr, nullptr, Qt::WidgetShortcut);
+	mvUpSc_ = std::make_unique<QShortcut>(Qt::CTRL | Qt::Key_Up, ui->listWidget, nullptr, nullptr, Qt::WidgetShortcut);
 	QObject::connect(mvUpSc_.get(), &QShortcut::activated, this, &BookmarkManagerForm::on_upToolButton_clicked);
-	mvDnSc_ = std::make_unique<QShortcut>(Qt::CTRL + Qt::Key_Down, ui->listWidget, nullptr, nullptr, Qt::WidgetShortcut);
+	mvDnSc_ = std::make_unique<QShortcut>(Qt::CTRL | Qt::Key_Down, ui->listWidget, nullptr, nullptr, Qt::WidgetShortcut);
 	QObject::connect(mvDnSc_.get(), &QShortcut::activated, this, &BookmarkManagerForm::on_downToolButton_clicked);
 }
 

--- a/BambooTracker/gui/configuration_dialog.cpp
+++ b/BambooTracker/gui/configuration_dialog.cpp
@@ -223,7 +223,7 @@ ConfigurationDialog::ConfigurationDialog(std::weak_ptr<Configuration> config, st
 		QObject::connect(button, &QToolButton::clicked, seq, &QKeySequenceEdit::clear);
 		auto layout = widget->layout();
 		layout->setSpacing(0);
-		layout->setMargin(0);
+		layout->setContentsMargins(0, 0, 0, 0);
 		layout->addWidget(seq);
 		layout->addWidget(button);
 		ui->shortcutsTreeWidget->setItemWidget(item, 1, widget);

--- a/BambooTracker/gui/drop_detect_list_widget.cpp
+++ b/BambooTracker/gui/drop_detect_list_widget.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Rerrah
+ * Copyright (C) 2020-2021 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -37,9 +37,10 @@ void DropDetectListWidget::dropEvent(QDropEvent* event)
 	QListWidget::dropEvent(event);
 
 	if (event->source() == this) {
-		QListWidgetItem* tgt = itemAt(event->pos());
+		QPoint pos = event->position().toPoint();
+		QListWidgetItem* tgt = itemAt(pos);
 		if (tgt == nullptr) return;
-		int tgtIdx = indexAt(event->pos()).row();
+		int tgtIdx = indexAt(pos).row();
 
 		int drpIdx;
 		{	// Only 1 item stored

--- a/BambooTracker/gui/drop_detect_list_widget.cpp
+++ b/BambooTracker/gui/drop_detect_list_widget.cpp
@@ -37,7 +37,11 @@ void DropDetectListWidget::dropEvent(QDropEvent* event)
 	QListWidget::dropEvent(event);
 
 	if (event->source() == this) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 		QPoint pos = event->position().toPoint();
+#else
+		QPoint pos = event->pos();
+#endif
 		QListWidgetItem* tgt = itemAt(pos);
 		if (tgt == nullptr) return;
 		int tgtIdx = indexAt(pos).row();

--- a/BambooTracker/gui/instrument_editor/adpcm_sample_editor.cpp
+++ b/BambooTracker/gui/instrument_editor/adpcm_sample_editor.cpp
@@ -200,7 +200,11 @@ bool ADPCMSampleEditor::eventFilter(QObject* obj, QEvent* ev)
 		}
 		case QEvent::HoverMove:
 		{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 			auto pos = dynamic_cast<QHoverEvent*>(ev)->position();
+#else
+			auto pos = dynamic_cast<QHoverEvent*>(ev)->pos();
+#endif
 			detectCursorSamplePosition(pos.x(), pos.y());
 
 			if (prevPressedSamp_.x() != -1) {	// Change sample

--- a/BambooTracker/gui/instrument_editor/adpcm_sample_editor.cpp
+++ b/BambooTracker/gui/instrument_editor/adpcm_sample_editor.cpp
@@ -200,7 +200,7 @@ bool ADPCMSampleEditor::eventFilter(QObject* obj, QEvent* ev)
 		}
 		case QEvent::HoverMove:
 		{
-			auto pos = dynamic_cast<QHoverEvent*>(ev)->pos();
+			auto pos = dynamic_cast<QHoverEvent*>(ev)->position();
 			detectCursorSamplePosition(pos.x(), pos.y());
 
 			if (prevPressedSamp_.x() != -1) {	// Change sample

--- a/BambooTracker/gui/instrument_editor/visualized_instrument_macro_editor.cpp
+++ b/BambooTracker/gui/instrument_editor/visualized_instrument_macro_editor.cpp
@@ -406,7 +406,7 @@ void VisualizedInstrumentMacroEditor::drawLoop()
 					painter.fillRect(w, loopY_, 2, fontHeight_, palette_->instSeqLoopEdgeColor);
 					QString times = (loops_[j].times == 1) ? "" : QString::number(loops_[j].times);
 					painter.drawText(QRectF(w + 2, loopY_, colWidth - 2, fontHeight_),
-									 Qt::AlignLeft + Qt::AlignVCenter, tr("Loop %1").arg(times));
+									 Qt::AlignLeft | Qt::AlignVCenter, tr("Loop %1").arg(times));
 				}
 				if (loops_[j].end == i) {
 					painter.fillRect(w + colWidth - 2, loopY_, 2,

--- a/BambooTracker/gui/instrument_editor/visualized_instrument_macro_editor.cpp
+++ b/BambooTracker/gui/instrument_editor/visualized_instrument_macro_editor.cpp
@@ -33,7 +33,7 @@
 #include <QApplication>
 #include <QFontMetrics>
 #include <QPainter>
-#include <QPoint>
+#include <QPointF>
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
 #include "gui/event_guard.hpp"
@@ -1091,7 +1091,7 @@ void VisualizedInstrumentMacroEditor::mouseHoverdEventInView(QHoverEvent* event)
 	int oldCol = hovCol_;
 	int oldRow = hovRow_;
 
-	QPoint pos = event->pos();
+	QPointF pos = event->position();
 
 	// Detect column
 	if (pos.x() < labWidth_) {

--- a/BambooTracker/gui/instrument_editor/visualized_instrument_macro_editor.cpp
+++ b/BambooTracker/gui/instrument_editor/visualized_instrument_macro_editor.cpp
@@ -33,7 +33,11 @@
 #include <QApplication>
 #include <QFontMetrics>
 #include <QPainter>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <QPointF>
+#else
+#include <QPoint>
+#endif
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
 #include "gui/event_guard.hpp"
@@ -1091,7 +1095,11 @@ void VisualizedInstrumentMacroEditor::mouseHoverdEventInView(QHoverEvent* event)
 	int oldCol = hovCol_;
 	int oldRow = hovRow_;
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	QPointF pos = event->position();
+#else
+	QPoint pos = event->pos();
+#endif
 
 	// Detect column
 	if (pos.x() < labWidth_) {

--- a/BambooTracker/gui/mainwindow.cpp
+++ b/BambooTracker/gui/mainwindow.cpp
@@ -41,7 +41,6 @@
 #include <QMimeData>
 #include <QProgressDialog>
 #include <QRect>
-#include <QDesktopWidget>
 #include <QMetaMethod>
 #include <QScreen>
 #include <QComboBox>

--- a/BambooTracker/gui/order_list_editor/order_list_panel.cpp
+++ b/BambooTracker/gui/order_list_editor/order_list_panel.cpp
@@ -105,7 +105,7 @@ OrderListPanel::OrderListPanel(QWidget *parent)
 	headerFont_.setPointSize(10);
 	rowFont_ = QFont("Monospace", 10);
 	rowFont_.setStyleHint(QFont::TypeWriter);
-	rowFont_.setStyleStrategy(QFont::ForceIntegerMetrics);
+	rowFont_.setStyleStrategy(QFont::PreferMatch);
 
 	updateSizes();
 

--- a/BambooTracker/gui/order_list_editor/order_list_panel.cpp
+++ b/BambooTracker/gui/order_list_editor/order_list_panel.cpp
@@ -37,6 +37,7 @@
 #include <QMenu>
 #include <QAction>
 #include <QPoint>
+#include <QPointF>
 #include <QString>
 #include <QIcon>
 #include "playback.hpp"
@@ -1494,22 +1495,23 @@ void OrderListPanel::mouseMoveEvent(QMouseEvent* event)
 			setSelectedRectangle(mousePressPos_, hovPos_);
 		}
 
-		if (event->x() < rowNumWidth_ && leftTrackVisIdx_ > 0) {
+		QPointF pos = event->position();
+		if (pos.x() < rowNumWidth_ && leftTrackVisIdx_ > 0) {
 			if (config_->getMoveCursorByHorizontalScroll())
 				moveCursorToRight(-1);
 			else
 				moveViewToRight(-1);
 		}
-		else if (event->x() > geometry().width() - rowNumWidth_ && hovPos_.trackVisIdx != -1) {
+		else if (pos.x() > geometry().width() - rowNumWidth_ && hovPos_.trackVisIdx != -1) {
 			if (config_->getMoveCursorByHorizontalScroll())
 				moveCursorToRight(1);
 			else
 				moveViewToRight(1);
 		}
-		if (event->pos().y() < headerHeight_ + rowFontHeight_) {
+		if (pos.y() < headerHeight_ + rowFontHeight_) {
 			if (!bt_->isPlaySong() || !bt_->isFollowPlay()) moveCursorToDown(-1);
 		}
-		else if (event->pos().y() > geometry().height() - rowFontHeight_) {
+		else if (pos.y() > geometry().height() - rowFontHeight_) {
 			if (!bt_->isPlaySong() || !bt_->isFollowPlay()) moveCursorToDown(1);
 		}
 	}
@@ -1567,7 +1569,7 @@ void OrderListPanel::mouseReleaseEvent(QMouseEvent* event)
 
 bool OrderListPanel::mouseHoverd(QHoverEvent *event)
 {
-	QPoint pos = event->pos();
+	QPointF pos = event->position();
 
 	OrderPosition oldPos = hovPos_;
 

--- a/BambooTracker/gui/order_list_editor/order_list_panel.cpp
+++ b/BambooTracker/gui/order_list_editor/order_list_panel.cpp
@@ -93,7 +93,7 @@ OrderListPanel::OrderListPanel(QWidget *parent)
 	  repaintingCnt_(0),
 	  playingRow_(-1),
 	  insSc1_(Qt::Key_Insert, this, nullptr, nullptr, Qt::WidgetShortcut),
-	  insSc2_(Qt::ALT + Qt::Key_B, this, nullptr, nullptr, Qt::WidgetShortcut),
+	  insSc2_(Qt::ALT | Qt::Key_B, this, nullptr, nullptr, Qt::WidgetShortcut),
 	  menuSc_(Qt::Key_Menu, this, nullptr, nullptr, Qt::WidgetShortcut)
 {
 	setAttribute(Qt::WA_Hover);
@@ -1088,8 +1088,8 @@ void OrderListPanel::showContextMenu(const OrderPosition& pos, const QPoint& poi
 	duplicate->setShortcut(gui_utils::strToKeySeq(shortcuts.at(Configuration::ShortcutAction::DuplicateOrder)));
 	clonep->setShortcut(gui_utils::strToKeySeq(shortcuts.at(Configuration::ShortcutAction::ClonePatterns)));
 	cloneo->setShortcut(gui_utils::strToKeySeq(shortcuts.at(Configuration::ShortcutAction::CloneOrder)));
-	copy->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_C));
-	paste->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_V));
+	copy->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_C));
+	paste->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_V));
 
 	if (pos.row < 0 || pos.trackVisIdx < 0) {
 		remove->setEnabled(false);

--- a/BambooTracker/gui/order_list_editor/order_list_panel.cpp
+++ b/BambooTracker/gui/order_list_editor/order_list_panel.cpp
@@ -37,7 +37,9 @@
 #include <QMenu>
 #include <QAction>
 #include <QPoint>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <QPointF>
+#endif
 #include <QString>
 #include <QIcon>
 #include "playback.hpp"
@@ -1495,7 +1497,11 @@ void OrderListPanel::mouseMoveEvent(QMouseEvent* event)
 			setSelectedRectangle(mousePressPos_, hovPos_);
 		}
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 		QPointF pos = event->position();
+#else
+		QPoint pos = event->pos();
+#endif
 		if (pos.x() < rowNumWidth_ && leftTrackVisIdx_ > 0) {
 			if (config_->getMoveCursorByHorizontalScroll())
 				moveCursorToRight(-1);
@@ -1569,7 +1575,11 @@ void OrderListPanel::mouseReleaseEvent(QMouseEvent* event)
 
 bool OrderListPanel::mouseHoverd(QHoverEvent *event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	QPointF pos = event->position();
+#else
+	QPoint pos = event->pos();
+#endif
 
 	OrderPosition oldPos = hovPos_;
 

--- a/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
+++ b/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
@@ -122,29 +122,29 @@ PatternEditorPanel::PatternEditorPanel(QWidget *parent)
 	  repaintingCnt_(0),
 	  isInitedFirstMod_(false),
 	  upSc_(Qt::Key_Up, this, nullptr, nullptr, Qt::WidgetShortcut),
-	  upWSSc_(Qt::SHIFT + Qt::Key_Up, this, nullptr, nullptr, Qt::WidgetShortcut),
+	  upWSSc_(Qt::SHIFT | Qt::Key_Up, this, nullptr, nullptr, Qt::WidgetShortcut),
 	  dnSc_(Qt::Key_Down, this, nullptr, nullptr, Qt::WidgetShortcut),
-	  dnWSSc_(Qt::SHIFT + Qt::Key_Down, this, nullptr, nullptr, Qt::WidgetShortcut),
+	  dnWSSc_(Qt::SHIFT | Qt::Key_Down, this, nullptr, nullptr, Qt::WidgetShortcut),
 	  pgUpSc_(Qt::Key_PageUp, this, nullptr, nullptr, Qt::WidgetShortcut),
-	  pgUpWSSc_(Qt::SHIFT + Qt::Key_PageUp, this, nullptr, nullptr, Qt::WidgetShortcut),
+	  pgUpWSSc_(Qt::SHIFT | Qt::Key_PageUp, this, nullptr, nullptr, Qt::WidgetShortcut),
 	  pgDnSc_(Qt::Key_PageDown, this, nullptr, nullptr, Qt::WidgetShortcut),
-	  pgDnWSSc_(Qt::SHIFT + Qt::Key_PageDown, this, nullptr, nullptr, Qt::WidgetShortcut),
+	  pgDnWSSc_(Qt::SHIFT | Qt::Key_PageDown, this, nullptr, nullptr, Qt::WidgetShortcut),
 	  homeSc_(Qt::Key_Home, this, nullptr, nullptr, Qt::WidgetShortcut),
-	  homeWSSc_(Qt::SHIFT + Qt::Key_Home, this, nullptr, nullptr, Qt::WidgetShortcut),
+	  homeWSSc_(Qt::SHIFT | Qt::Key_Home, this, nullptr, nullptr, Qt::WidgetShortcut),
 	  endSc_(Qt::Key_End, this, nullptr, nullptr, Qt::WidgetShortcut),
-	  endWSSc_(Qt::SHIFT + Qt::Key_End, this, nullptr, nullptr, Qt::WidgetShortcut),
+	  endWSSc_(Qt::SHIFT | Qt::Key_End, this, nullptr, nullptr, Qt::WidgetShortcut),
 	  hlUpSc_(QKeySequence(), this, nullptr, nullptr, Qt::WidgetShortcut),
 	  hlUpWSSc_(QKeySequence(), this, nullptr, nullptr, Qt::WidgetShortcut),
 	  hlDnSc_(QKeySequence(), this, nullptr, nullptr, Qt::WidgetShortcut),
 	  hlDnWSSc_(QKeySequence(), this, nullptr, nullptr, Qt::WidgetShortcut),
 	  ltSc_(Qt::Key_Left, this, nullptr, nullptr, Qt::WidgetShortcut),
-	  ltWSSc_(Qt::SHIFT + Qt::Key_Left, this, nullptr, nullptr, Qt::WidgetShortcut),
+	  ltWSSc_(Qt::SHIFT | Qt::Key_Left, this, nullptr, nullptr, Qt::WidgetShortcut),
 	  rtSc_(Qt::Key_Right, this, nullptr, nullptr, Qt::WidgetShortcut),
-	  rtWSSc_(Qt::SHIFT + Qt::Key_Right, this, nullptr, nullptr, Qt::WidgetShortcut),
+	  rtWSSc_(Qt::SHIFT | Qt::Key_Right, this, nullptr, nullptr, Qt::WidgetShortcut),
 	  keyOffSc_(QKeySequence(), this, nullptr, nullptr, Qt::WidgetShortcut),
 	  echoBufSc_(QKeySequence(), this, nullptr, nullptr, Qt::WidgetShortcut),
-	  stepMvUpSc_(Qt::ALT + Qt::Key_Up, this, nullptr, nullptr, Qt::WidgetShortcut),
-	  stepMvDnSc_(Qt::ALT + Qt::Key_Down, this, nullptr, nullptr, Qt::WidgetShortcut),
+	  stepMvUpSc_(Qt::ALT | Qt::Key_Up, this, nullptr, nullptr, Qt::WidgetShortcut),
+	  stepMvDnSc_(Qt::ALT | Qt::Key_Down, this, nullptr, nullptr, Qt::WidgetShortcut),
 	  expandColSc_(QKeySequence(), this, nullptr, nullptr, Qt::WidgetShortcut),
 	  shrinkColSc_(QKeySequence(), this, nullptr, nullptr, Qt::WidgetShortcut)
 {	
@@ -2182,12 +2182,12 @@ void PatternEditorPanel::showPatternContextMenu(const PatternPosition& pos, cons
 	sheff->setShortcutVisibleInContextMenu(true);
 #endif
 	auto shortcuts = config_->getShortcuts();
-	undo->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_Z));
-	redo->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_Y));
-	undo->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_Z));
-	copy->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_C));
-	cut->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_X));
-	paste->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_V));
+	undo->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_Z));
+	redo->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_Y));
+	undo->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_Z));
+	copy->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_C));
+	cut->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_X));
+	paste->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_V));
 	pasteMix->setShortcut(gui_utils::strToKeySeq(shortcuts.at(Configuration::ShortcutAction::PasteMix)));
 	pasteOver->setShortcut(gui_utils::strToKeySeq(shortcuts.at(Configuration::ShortcutAction::PasteOverwrite)));
 	pasteIns->setShortcut(gui_utils::strToKeySeq(shortcuts.at(Configuration::ShortcutAction::PasteInsert)));

--- a/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
+++ b/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
@@ -157,7 +157,7 @@ PatternEditorPanel::PatternEditorPanel(QWidget *parent)
 	headerFont_.setPointSize(10);
 	stepFont_ = QFont("Monospace", 10);
 	stepFont_.setStyleHint(QFont::TypeWriter);
-	stepFont_.setStyleStrategy(QFont::ForceIntegerMetrics);
+	stepFont_.setStyleStrategy(QFont::PreferMatch);
 
 	updateSizes();
 

--- a/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
+++ b/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
@@ -35,6 +35,7 @@
 #include <QFontMetrics>
 #include <QFontInfo>
 #include <QPoint>
+#include <QPointF>
 #include <QApplication>
 #include <QClipboard>
 #include <QMenu>
@@ -2889,7 +2890,8 @@ void PatternEditorPanel::mouseMoveEvent(QMouseEvent* event)
 			setSelectedRectangle(mousePressPos_, hovPos_);
 		}
 
-		if (event->x() < stepNumWidth_ && leftTrackVisIdx_ > 0) {
+		QPointF pos = event->position();
+		if (pos.x() < stepNumWidth_ && leftTrackVisIdx_ > 0) {
 			if (config_->getMoveCursorByHorizontalScroll()) {
 				moveCursorToRight(-(5 + 2 * rightEffn_.at(static_cast<size_t>(leftTrackVisIdx_) - 1)));
 			}
@@ -2897,7 +2899,7 @@ void PatternEditorPanel::mouseMoveEvent(QMouseEvent* event)
 				moveViewToRight(-1);
 			}
 		}
-		else if (event->x() > geometry().width() - stepNumWidth_ && hovPos_.trackVisIdx != -1) {
+		else if (pos.x() > geometry().width() - stepNumWidth_ && hovPos_.trackVisIdx != -1) {
 			if (config_->getMoveCursorByHorizontalScroll()) {
 				moveCursorToRight(5 + 2 * rightEffn_.at(static_cast<size_t>(leftTrackVisIdx_)));
 			}
@@ -2905,10 +2907,10 @@ void PatternEditorPanel::mouseMoveEvent(QMouseEvent* event)
 				moveViewToRight(1);
 			}
 		}
-		if (event->pos().y() < headerHeight_ + stepFontHeight_) {
+		if (pos.y() < headerHeight_ + stepFontHeight_) {
 			if (!bt_->isPlaySong() || !bt_->isFollowPlay()) moveCursorToDown(-1);
 		}
-		else if (event->pos().y() > geometry().height() - stepFontHeight_) {
+		else if (pos.y() > geometry().height() - stepFontHeight_) {
 			if (!bt_->isPlaySong() || !bt_->isFollowPlay()) moveCursorToDown(1);
 		}
 	}
@@ -3058,7 +3060,7 @@ void PatternEditorPanel::mouseDoubleClickEvent(QMouseEvent* event)
 
 bool PatternEditorPanel::mouseHoverd(QHoverEvent *event)
 {
-	QPoint pos = event->pos();
+	QPointF pos = event->position();
 	PatternPosition oldPos = hovPos_;
 
 	// Detect Step

--- a/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
+++ b/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
@@ -35,7 +35,9 @@
 #include <QFontMetrics>
 #include <QFontInfo>
 #include <QPoint>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <QPointF>
+#endif
 #include <QApplication>
 #include <QClipboard>
 #include <QMenu>
@@ -2890,7 +2892,11 @@ void PatternEditorPanel::mouseMoveEvent(QMouseEvent* event)
 			setSelectedRectangle(mousePressPos_, hovPos_);
 		}
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 		QPointF pos = event->position();
+#else
+		QPoint pos = event->pos();
+#endif
 		if (pos.x() < stepNumWidth_ && leftTrackVisIdx_ > 0) {
 			if (config_->getMoveCursorByHorizontalScroll()) {
 				moveCursorToRight(-(5 + 2 * rightEffn_.at(static_cast<size_t>(leftTrackVisIdx_) - 1)));
@@ -3060,7 +3066,11 @@ void PatternEditorPanel::mouseDoubleClickEvent(QMouseEvent* event)
 
 bool PatternEditorPanel::mouseHoverd(QHoverEvent *event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	QPointF pos = event->position();
+#else
+	QPoint pos = event->pos();
+#endif
 	PatternPosition oldPos = hovPos_;
 
 	// Detect Step

--- a/BambooTracker/main.cpp
+++ b/BambooTracker/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char* argv[])
 		std::shared_ptr<Configuration> config = std::make_shared<Configuration>();
 		io::loadConfiguration(config);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 		QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 
@@ -94,14 +94,16 @@ void setupTranslations()
 
 	if (!qtDir.isEmpty()) {
 		QString baseName = "qt_" + lang;
-		qtTr->load(baseName, qtDir);
-		qDebug() << "Translation" << baseName << "from" << qtDir;
+		if (qtTr->load(baseName, qtDir)) {
+			qDebug() << "Translation" << baseName << "from" << qtDir;
+		}
 	}
 
 	if (!appDir.isEmpty()) {
 		QString baseName = "bamboo_tracker_" + lang;
-		appTr->load(baseName, appDir);
-		qDebug() << "Translation" << baseName << "from" << appDir;
+		if (appTr->load(baseName, appDir)) {
+			qDebug() << "Translation" << baseName << "from" << appDir;
+		}
 	}
 
 	a->installTranslator(qtTr);

--- a/BambooTracker/main.cpp
+++ b/BambooTracker/main.cpp
@@ -125,7 +125,11 @@ QString findQtTranslationsDir()
 	return QApplication::applicationDirPath() + "/lang";
 #else
 	// the files are located in the installation of Qt
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	return QLibraryInfo::path(QLibraryInfo::TranslationsPath);
+#else
 	return QLibraryInfo::location(QLibraryInfo::TranslationsPath);
+#endif
 #endif
 }
 

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ See [FILEIO.md](./FILEIO.md).
 ### Dependencies
 To build BambooTracker, you'll need the following dependencies across all platforms:
 
-- Qt5
-- Qt5 Tools (qmake, lrelease, ...)
+- Qt (5.5 or higher)
+- Qt Tools (qmake, lrelease, ...)
 - A Qt-supported C++ compiler (GCC, Clang, MSVC, ...)
 - make
 
@@ -162,11 +162,11 @@ How to acquire these and further required / optional dependencies are specific t
     Untested but might work.
   - MSVC  
     Either bundled with [Visual Studio](https://visualstudio.microsoft.com) or standalone (check "Build Tools for Visual Studio 2019" download).
-- [Qt5](https://www.qt.io/download-qt-installer)  
+- [Qt](https://www.qt.io/download-qt-installer)
   Older Qt versions (e.g. for an XP builds) may require you to checkout & compile Qt yourself, official prebuilt versions were removed by Qt.
 
 #### macOS
-For simplicity, these instructions assume the use of [Homebrew](https://brew.sh/).
+For simplicity, these instructions assume the use of [Homebrew](https://brew.sh/) & Qt5.
 
 - C++ compiler: Xcode Command Line Tools  
   The challenge of acquiring these is left to the reader.  
@@ -324,7 +324,7 @@ make install
 ```
 
 #### Windows
-Enter a shell with Qt5 + your compiler set up before starting the above steps. (Qt5 installer adds scripts you can use for this)
+Enter a shell with Qt + your compiler set up before starting the above steps. (Qt installer adds scripts you can use for this)
 
 - If you're using MinGW, use `mingw32-make` / `mingw64-make` instead of `make`.
 - If you're using MSVC, **TODO**.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@
   </a>
   <br />
   (Build tests)<br />
-  <a href="https://github.com/rerrahkr/BambooTracker/actions?query=workflow%3A%22Windows+%287+and+up%29%22">
-    <img src="https://img.shields.io/github/workflow/status/rerrahkr/BambooTracker/Windows%20(7%20and%20up)?logo=windows&logoColor=white" alt="BambooTracker Build-Test Status on Windows" />
+  <a href="https://github.com/rerrahkr/BambooTracker/actions?query=workflow%3A%22Windows+7+and+up+%2832-bit%2C+Qt5%29%22">
+    <img src="https://img.shields.io/github/workflow/status/rerrahkr/BambooTracker/Windows%207%20and%20up%20(32-bit,%20Qt5)?logo=windows&logoColor=white" alt="BambooTracker Build-Test Status on Windows (Qt5)" />
+  </a>
+  <a href="https://github.com/rerrahkr/BambooTracker/actions?query=workflow%3A%22Windows+10+%2864-bit%2C+Qt6%29%22">
+    <img src="https://img.shields.io/github/workflow/status/rerrahkr/BambooTracker/Windows%2010%20(64-bit,%20Qt6)?logo=windows&logoColor=white" alt="BambooTracker Build-Test Status on Windows (Qt6)" />
   </a>
   <a href="https://github.com/rerrahkr/BambooTracker/actions?query=workflow%3AmacOS">
     <img src="https://img.shields.io/github/workflow/status/rerrahkr/BambooTracker/macOS?logo=apple&logoColor=white" alt="BambooTracker Build-Test Status on macOS" />

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <br />
   (Build tests)<br />
   <a href="https://github.com/rerrahkr/BambooTracker/actions?query=workflow%3A%22Windows+7+and+up+%2832-bit%2C+Qt5%29%22">
-    <img src="https://img.shields.io/github/workflow/status/rerrahkr/BambooTracker/Windows%207%20and%20up%20(32-bit,%20Qt5)?logo=windows&logoColor=white" alt="BambooTracker Build-Test Status on Windows (Qt5)" />
+    <img src="https://img.shields.io/github/workflow/status/rerrahkr/BambooTracker/Windows%207%20and%20up%20(32-bit,%20Qt5)?logo=windows-xp&logoColor=white" alt="BambooTracker Build-Test Status on Windows (Qt5)" />
   </a>
   <a href="https://github.com/rerrahkr/BambooTracker/actions?query=workflow%3A%22Windows+10+%2864-bit%2C+Qt6%29%22">
     <img src="https://img.shields.io/github/workflow/status/rerrahkr/BambooTracker/Windows%2010%20(64-bit,%20Qt6)?logo=windows&logoColor=white" alt="BambooTracker Build-Test Status on Windows (Qt6)" />

--- a/README_ja.md
+++ b/README_ja.md
@@ -146,8 +146,8 @@ pkg install bambootracker
 ### 依存関係
 BambooTrackerをビルドする際には全てのプラットフォームで以下の依存関係を用意してください。
 
-- Qt5 
-- Qt5 Tools (qmake, lrelease, ...)
+- Qt (5.5以降)
+- Qt Tools (qmake, lrelease, ...)
 - QtでサポートされているC++コンパイラ (GCC, Clang, MSVC, ...)
 - make
 
@@ -162,12 +162,11 @@ BambooTrackerをビルドする際には全てのプラットフォームで以�
     未テストですが恐らく動作します。
   - MSVC  
     [Visual Studio](https://visualstudio.microsoft.com)にバンドルされているものか、スタンドアロン版("Build Tools for Visual Studio 2019"のダウンロードを確認してください)
-- [Qt5](https://www.qt.io/download-qt-installer)  
-  Older Qt versions (e.g. for an XP builds) may require you to checkout & compile Qt yourself, official prebuilt versions were removed by Qt.
+- [Qt](https://www.qt.io/download-qt-installer)
   古いバージョンのQt(XPビルドなど)では、自分でチェックアウトしてコンパイルする必要があるかもしれませんが、公式のプリビルド版はQtによって削除されました。
 
 #### macOS
-ここではHomebrewを用いた導入方法を紹介します。
+ここではHomebrew & Qt5を用いた導入方法を紹介します。
 
 - C++コンパイラ: Xcode Command Line Tools  
   (開発者はmacOSを使っていないので、導入方法については検索してください。すみません)
@@ -326,7 +325,7 @@ make install
 ```
 
 #### Windows
-上記の手順を始める前に、Qt5とコンパイラをセットアップしたシェルに入ります。(Qt5のインストーラには、このために使えるスクリプトが追加されています)
+上記の手順を始める前に、Qtとコンパイラをセットアップしたシェルに入ります。(Qtのインストーラには、このために使えるスクリプトが追加されています)
 
 - MinGWを使う場合は`make`ではなく`mingw32-make` / `mingw64-make`を使って下さい.
 - MSVCを使う場合は**TODO**。

--- a/README_ja.md
+++ b/README_ja.md
@@ -18,7 +18,7 @@
     <img src="https://img.shields.io/github/workflow/status/rerrahkr/BambooTracker/Windows%207%20and%20up%20(32-bit,%20Qt5)?logo=windows&logoColor=white" alt="BambooTracker Build-Test Status on Windows (Qt5)" />
   </a>
   <a href="https://github.com/rerrahkr/BambooTracker/actions?query=workflow%3A%22Windows+10+%2864-bit%2C+Qt6%29%22">
-    <img src="https://img.shields.io/github/workflow/status/rerrahkr/BambooTracker/Windows%2010%20(64-bit,%20Qt6)?logo=windows&logoColor=white" alt="BambooTracker Build-Test Status on Windows (Qt6)" />
+    <img src="https://img.shields.io/github/workflow/status/rerrahkr/BambooTracker/Windows%2010%20(64-bit,%20Qt6)?logo=windows-xp&logoColor=white" alt="BambooTracker Build-Test Status on Windows (Qt6)" />
   </a>
   <a href="https://github.com/rerrahkr/BambooTracker/actions?query=workflow%3AmacOS">
     <img src="https://img.shields.io/github/workflow/status/rerrahkr/BambooTracker/macOS?logo=apple&logoColor=white" alt="BambooTracker Build-Test Status on macOS" />

--- a/README_ja.md
+++ b/README_ja.md
@@ -14,8 +14,11 @@
   </a>
   <br />
   (Build tests)<br />
-  <a href="https://github.com/rerrahkr/BambooTracker/actions?query=workflow%3A%22Windows+%287+and+up%29%22">
-    <img src="https://img.shields.io/github/workflow/status/rerrahkr/BambooTracker/Windows%20(7%20and%20up)?logo=windows&logoColor=white" alt="BambooTracker Build-Test Status on Windows" />
+  <a href="https://github.com/rerrahkr/BambooTracker/actions?query=workflow%3A%22Windows+7+and+up+%2832-bit%2C+Qt5%29%22">
+    <img src="https://img.shields.io/github/workflow/status/rerrahkr/BambooTracker/Windows%207%20and%20up%20(32-bit,%20Qt5)?logo=windows&logoColor=white" alt="BambooTracker Build-Test Status on Windows (Qt5)" />
+  </a>
+  <a href="https://github.com/rerrahkr/BambooTracker/actions?query=workflow%3A%22Windows+10+%2864-bit%2C+Qt6%29%22">
+    <img src="https://img.shields.io/github/workflow/status/rerrahkr/BambooTracker/Windows%2010%20(64-bit,%20Qt6)?logo=windows&logoColor=white" alt="BambooTracker Build-Test Status on Windows (Qt6)" />
   </a>
   <a href="https://github.com/rerrahkr/BambooTracker/actions?query=workflow%3AmacOS">
     <img src="https://img.shields.io/github/workflow/status/rerrahkr/BambooTracker/macOS?logo=apple&logoColor=white" alt="BambooTracker Build-Test Status on macOS" />

--- a/scripts/fetch_mingw.sh
+++ b/scripts/fetch_mingw.sh
@@ -2,19 +2,26 @@
 
 set -e
 
-if [[ "$#" -lt 2 ]]; then
+if [[ "$#" -lt 3 ]]; then
   echo "Incomplete list of arguments." >&2
-  echo "Need: <target-dir> <target-version>" >&2
+  echo "Need: <target-dir> <target-version> <target-bitness> [<target-cachedir>]" >&2
   exit 1
 fi
 
 MINGW_TARGETDIR="$1"
 MINGW_TARGETVER="$2"
-MINGW_TARGETNEWDIR="$3"
+MINGW_TARGETBIT="$3"
+MINGW_TARGETNEWDIR="$4"
 
-echo "Test if fetching x86 MinGW ${MINGW_TARGETVER} is required..."
+if [[ ${MINGW_TARGETBIT} -ne 32 && ${MINGW_TARGETBIT} -ne 64 ]]; then
+  echo "Invalid bitness! Must be '32' or '64', was '${MINGW_TARGETBIT}'!" >&2
+  exit 1
+fi
+
+echo "Test if fetching MinGW ${MINGW_TARGETVER} is required..."
 
 if [[
+  x${MINGW_TARGETNEWDIR} == x &&
   -d ${MINGW_TARGETDIR}/bin &&
   -f ${MINGW_TARGETDIR}/bin/g++ &&
   $(${MINGW_TARGETDIR}/bin/g++ -dumpversion) == ${MINGW_TARGETVER}
@@ -24,14 +31,19 @@ if [[
   -f ${MINGW_TARGETNEWDIR}/bin/g++ &&
   $(${MINGW_TARGETNEWDIR}/bin/g++ -dumpversion) == ${MINGW_TARGETVER}
 ]]; then
-  echo "x86 MinGW ${MINGW_TARGETVER} seems cached."
-  echo "If cache is incorrect, please invalidate the cache and restart the build."
+  echo "A suitable MinGW installation already seems to exist at ${MINGW_TARGETNEWDIR:-$MINGW_TARGETDIR}!"
+  echo "If this is incorrect, please invalidate the cache and restart the build."
   exit 0
 else
-  echo "Fetching x86 MinGW ${MINGW_TARGETVER}."
-  choco install -q mingw --version=${MINGW_TARGETVER} -x86 -params "/exception:dwarf" --force
-  if [ x${MINGW_TARGETNEWDIR} != x ]; then
-    echo "Override directory specified, copying x86 MinGW ${MINGW_TARGETVER} from"
+  echo "Fetching ${MINGW_TARGETBIT}-bit MinGW ${MINGW_TARGETVER}."
+  MINGW_TARGETARGS=
+  if [[ ${MINGW_TARGETBIT} -eq 32 ]]; then
+    MINGW_TARGETARGS='-x86 -params "/exception:dwarf"'
+  fi
+  choco install -q mingw --version=${MINGW_TARGETVER} ${MINGW_TARGETARGS} --force
+  if [[ x${MINGW_TARGETNEWDIR} != x ]]; then
+    echo "Cache-helper enabled."
+    echo "Copying ${MINGW_TARGETBIT}-bit MinGW ${MINGW_TARGETVER} from"
     echo "'${MINGW_TARGETDIR}' to"
     echo "'${MINGW_TARGETNEWDIR}'"
     echo "and reassigning it to $(whoami)."
@@ -40,7 +52,7 @@ else
     chown -R $(whoami) ${MINGW_TARGETNEWDIR}
     chmod -R 755 ${MINGW_TARGETNEWDIR}
   fi
-  echo "x86 MinGW ${MINGW_TARGETVER} is fetched."
+  echo "${MINGW_TARGETBIT}-bit MinGW ${MINGW_TARGETVER} is fetched."
   exit 0
 fi
 

--- a/scripts/fetch_qt.sh
+++ b/scripts/fetch_qt.sh
@@ -13,7 +13,17 @@ QT_TARGETVER="$2"
 QT_TARGETTCH="$3"
 
 shift 3
-QT_TARGETCMP="$@"
+
+QT6_QT5COMPAT=
+QT_TARGETCMP=
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" = "qt5compat" ]]; then
+    QT6_QT5COMPAT=yes
+  else
+    QT_TARGETCMP="${QT_TARGETCMP}"${QT_TARGETCMP:+' '}"$1"
+  fi
+  shift 1
+done
 
 echo "Test if fetching Qt freshly is required."
 
@@ -24,6 +34,9 @@ if [[ -d "$QT_TARGETDIR"/"$QT_TARGETVER" ]]; then
 else
   curl https://code.qt.io/cgit/qbs/qbs.git/plain/scripts/install-qt.sh > install-qt.sh
   bash ./install-qt.sh -d "$QT_TARGETDIR" --host "windows_x86" --version "$QT_TARGETVER" --toolchain "$QT_TARGETTCH" $QT_TARGETCMP
+  if [ x$QT6_QT5COMPAT != x ]; then
+    bash ./install-qt.sh -d "$QT_TARGETDIR" --host "windows_x86" --version "$QT_TARGETVER" --toolchain "qt5compat.$QT_TARGETTCH" "qt5compat"
+  fi
   echo "Qt fetched."
   if [[ "$(echo "$QT_TARGETCMP" | grep essentials 2>&1 >/dev/null; echo $?)" -eq 0 ]]; then
     echo "Older Qt version detected, manually patching setup."

--- a/submodules/RtAudio/RtAudio.pro
+++ b/submodules/RtAudio/RtAudio.pro
@@ -17,7 +17,7 @@ else {
     DEFINES += __WINDOWS_DS__
     LIBS += -lole32 -lwinmm -ldsound -luser32
 
-    greaterThan(QT_MAJOR_VERSION, 4):greaterThan(QT_MINOR_VERSION, 5) {
+    if(equals(QT_MAJOR_VERSION, 5):greaterThan(QT_MINOR_VERSION, 5))|greaterThan(QT_MAJOR_VERSION, 5) {
       message("[default] Adding WASAPI")
       DEFINES += __WINDOWS_WASAPI__
       LIBS += -lksuser -lmfplat -lmfuuid -lwmcodecdspuuid


### PR DESCRIPTION
Closes #298.

The goal here is to get BambooTracker compiled & running on Qt6. I don't think moving the regular Windows CI to Qt6 is a good idea because it only supports 64-bit Windows 10, so I made a new GHA target.

("Windows 7 and up" should eventually be downgraded to 5.12, I noticed. 5.15 is only a LTS release for commercial Qt users and was only supported until Qt6 was released. 5.12 is still under free long-term support until December 2021)

Compared to #298, I've bumped the Qt6 version to yesterday's Qt6.1.0 Alpha release and fixed the MinGW script to support 64-bit and 32-bit fetching.

TODOs:

- [x] Get it compiled on CI with minimal changes
- [x] Check if `windeployqt` finds all MinGW DLLs, figure out why not if it doesn't
- [x] Fix WASAPI capability detection in RtAudio.pro
- [x] Test on a supported system

Future TODOs:
- [ ] Build without Qt5 compatibility module (`qt5compat`)
- [x] Build without warning disable flags
  - [x] `-Wno-error=deprecated-declarations`
  - [x] `-Wno-error=unused-result`
- [x] Check Darwin Qt6 once GHA/Homebrew forces it on us