### PR TITLE
Add YM2610B to the target of VGM export

### DIFF
--- a/BambooTracker/chip/register_write_logger.cpp
+++ b/BambooTracker/chip/register_write_logger.cpp
@@ -96,16 +96,19 @@ void VgmLogger::recordRegisterChange(uint32_t offset, uint8_t value)
 			(ssg != io::Export_InternalSsg) ? 0xa0
 											: (fm == io::Export_YM2608) ? 0x56
 																		: (fm == io::Export_YM2203) ? 0x55
-																									: 0x00;
+																									: (fm == io::Export_YM2610B) ? 0x58
+																																 : 0x00;
 	const uint8_t cmdFmPortA =
 			(fm == io::Export_YM2608) ? 0x56
 									  : (fm == io::Export_YM2612) ? 0x52
 																  : (fm == io::Export_YM2203) ? 0x55
-																							  : 0x00;
+																							  : (fm == io::Export_YM2610B) ? 0x58
+																														   : 0x00;
 	const uint8_t cmdFmPortB =
 			(fm == io::Export_YM2608) ? 0x57
 									  : (fm == io::Export_YM2612) ? 0x53
-																  : 0x00;
+																  : (fm == io::Export_YM2610B) ? 0x59
+																							   : 0x00;
 
 	if (cmdSsg && offset < 0x10) {
 		buf_.push_back(cmdSsg);

--- a/BambooTracker/gui/vgm_export_settings_dialog.cpp
+++ b/BambooTracker/gui/vgm_export_settings_dialog.cpp
@@ -215,6 +215,8 @@ int VgmExportSettingsDialog::getExportTarget() const
 		target |= io::Export_YM2612;
 	else if (ui->ym2203RadioButton->isChecked())
 		target |= io::Export_YM2203;
+	else if (ui->ym2610bRadioButton->isChecked())
+		target |= io::Export_YM2610B;
 
 	if (ui->ay8910PsgRadioButton->isChecked())
 		target |= io::Export_AY8910Psg;
@@ -244,7 +246,7 @@ void VgmExportSettingsDialog::updateSupportInformation()
 		break;
 	}
 
-	bool haveSsg = fm == io::Export_YM2608 || fm == io::Export_YM2203 || ssg != io::Export_InternalSsg;
+	bool haveSsg = fm == io::Export_YM2608 || fm == io::Export_YM2203 || fm == io::Export_YM2610B || ssg != io::Export_InternalSsg;
 	bool haveRhythm = fm == io::Export_YM2608;
 	bool haveAdpcm = fm == io::Export_YM2608;
 

--- a/BambooTracker/gui/vgm_export_settings_dialog.ui
+++ b/BambooTracker/gui/vgm_export_settings_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>491</width>
-    <height>622</height>
+    <width>507</width>
+    <height>654</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -374,6 +374,13 @@
           </widget>
          </item>
          <item>
+          <widget class="QRadioButton" name="ym2610bRadioButton">
+           <property name="text">
+            <string>YM2610B OPNB</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QRadioButton" name="noneFmRadioButton">
            <property name="text">
             <string>None</string>
@@ -539,6 +546,19 @@
            </property>
           </widget>
          </item>
+         <item row="4" column="0">
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
         </layout>
        </widget>
       </item>
@@ -573,6 +593,7 @@
   <tabstop>ym2608RadioButton</tabstop>
   <tabstop>ym2612RadioButton</tabstop>
   <tabstop>ym2203RadioButton</tabstop>
+  <tabstop>ym2610bRadioButton</tabstop>
   <tabstop>noneFmRadioButton</tabstop>
   <tabstop>internalSsgRadioButton</tabstop>
   <tabstop>ay8910PsgRadioButton</tabstop>

--- a/BambooTracker/io/export_io.cpp
+++ b/BambooTracker/io/export_io.cpp
@@ -50,40 +50,44 @@ void writeVgm(BinaryContainer& container, int target, const std::vector<uint8_t>
 	uint8_t header[0x100] = {'V', 'g', 'm', ' '};
 	// 0x04: EOF offset
 	uint32_t offset = 0x100 + samples.size() + 1 + tagLen - 4;
-	*reinterpret_cast<uint32_t *>(header + 0x04) = offset;
+	*reinterpret_cast<uint32_t*>(header + 0x04) = offset;
 	// 0x08: Version [v1.71]
 	uint32_t version = 0x171;
-	*reinterpret_cast<uint32_t *>(header + 0x08) = version;
+	*reinterpret_cast<uint32_t*>(header + 0x08) = version;
 	// 0x14: GD3 offset
 	uint32_t gd3Offset = gd3TagEnabled ? (0x100 + samples.size() + 1 - 0x14) : 0;
-	*reinterpret_cast<uint32_t *>(header + 0x14) = gd3Offset;
+	*reinterpret_cast<uint32_t*>(header + 0x14) = gd3Offset;
 	// 0x18: Total # samples
-	*reinterpret_cast<uint32_t *>(header + 0x18) = totalSamples;
+	*reinterpret_cast<uint32_t*>(header + 0x18) = totalSamples;
 	// 0x1c: Loop offset
 	uint32_t loopOffset = loopFlag ? (loopPoint + 0x100 - 0x1c) : 0;
-	*reinterpret_cast<uint32_t *>(header + 0x1c) = loopOffset;
+	*reinterpret_cast<uint32_t*>(header + 0x1c) = loopOffset;
 	// 0x20: Loop # samples
 	uint32_t loopSamps = loopFlag ? loopSamples : 0;
-	*reinterpret_cast<uint32_t *>(header + 0x20) = loopSamps;
+	*reinterpret_cast<uint32_t*>(header + 0x20) = loopSamps;
 	// 0x24: Rate
-	*reinterpret_cast<uint32_t *>(header + 0x24) = rate;
+	*reinterpret_cast<uint32_t*>(header + 0x24) = rate;
 	// 0x34: VGM data offset
 	uint32_t dataOffset = 0xcc;
-	*reinterpret_cast<uint32_t *>(header + 0x34) = dataOffset;
+	*reinterpret_cast<uint32_t*>(header + 0x34) = dataOffset;
 
 	switch (target & Export_FmMask) {
 	default:
 	case Export_YM2608:
 		// 0x48: YM2608 clock
-		*reinterpret_cast<uint32_t *>(header + 0x48) = clock;
+		*reinterpret_cast<uint32_t*>(header + 0x48) = clock;
 		break;
 	case Export_YM2612:
 		// 0x2c: YM2612 clock
-		*reinterpret_cast<uint32_t *>(header + 0x2c) = clock;
+		*reinterpret_cast<uint32_t*>(header + 0x2c) = clock;
 		break;
 	case Export_YM2203:
 		// 0x44: YM2203 clock
-		*reinterpret_cast<uint32_t *>(header + 0x44) = clock / 2;
+		*reinterpret_cast<uint32_t*>(header + 0x44) = clock / 2;
+		break;
+	case Export_YM2610B:
+		// 0x4c: YM2610/B clock
+		*reinterpret_cast<uint32_t*>(header + 0x4c) = clock;
 		break;
 	case Export_NoneFm:
 		break;
@@ -94,12 +98,12 @@ void writeVgm(BinaryContainer& container, int target, const std::vector<uint8_t>
 		break;
 	default:
 		// 0x74: AY8910 clock
-		*reinterpret_cast<uint32_t *>(header + 0x74) = clock / 4;
+		*reinterpret_cast<uint32_t*>(header + 0x74) = clock / 4;
 		// 0x78: AY8910 chip type
 		if ((target & Export_SsgMask) == Export_YM2149Psg)
-			*reinterpret_cast<uint32_t *>(header + 0x78) = 0x10;
+			*reinterpret_cast<uint32_t*>(header + 0x78) = 0x10;
 		// 0x79: AY8910 flags
-		*reinterpret_cast<uint32_t *>(header + 0x79) = 0x01;
+		*reinterpret_cast<uint32_t*>(header + 0x79) = 0x01;
 		break;
 	}
 

--- a/BambooTracker/io/export_io.hpp
+++ b/BambooTracker/io/export_io.hpp
@@ -73,7 +73,8 @@ enum ExportTargetFlag
 	Export_YM2608 = 1,
 	Export_YM2612 = 2,
 	Export_YM2203 = 4,
-	Export_FmMask = Export_NoneFm|Export_YM2608|Export_YM2612|Export_YM2203,
+	Export_YM2610B = 8,
+	Export_FmMask = Export_NoneFm | Export_YM2608 | Export_YM2612 | Export_YM2203 | Export_YM2610B,
 	/* target bit 4-5 : SSG type */
 	Export_InternalSsg = 0,
 	Export_AY8910Psg = 16,


### PR DESCRIPTION
Close #335

Refer to a datasheet, it seems that YM2610B has ADPCM-B registers between 0x10 and 0x1C in bank 0, however, YM2608 has the one between 0x00 and 0x10 in bank 1. YM2608 also remove several registers such as `LIMIT ADR` from YM2608.

There is [another difference about a step size](https://github.com/rerrahkr/BambooTracker/issues/335#issuecomment-781149396), I exclude ADPCM-B since it is impossible to convert register values simply.