### PR TITLE
Polish note notation fix

### DIFF
--- a/BambooTracker/lang/bamboo_tracker_pl.ts
+++ b/BambooTracker/lang/bamboo_tracker_pl.ts
@@ -86,7 +86,7 @@
     <message>
         <location filename="../gui/instrument_editor/adpcm_sample_editor.ui" line="247"/>
         <source>B</source>
-        <translation>B</translation>
+        <translation>H</translation>
     </message>
     <message>
         <location filename="../gui/instrument_editor/adpcm_sample_editor.ui" line="265"/>
@@ -734,7 +734,7 @@
         <location filename="../gui/configuration_dialog.ui" line="1672"/>
         <location filename="../gui/configuration_dialog.ui" line="2520"/>
         <source>B</source>
-        <translation>B</translation>
+        <translation>H</translation>
     </message>
     <message>
         <location filename="../gui/configuration_dialog.ui" line="1972"/>


### PR DESCRIPTION
addresses the certain aspect of #345 - some European countries use different notation -CDEFGAH rather than CDEFGAB. Poland is one of them, so here's fix