### PR TITLE
Bump Qt versions on Windows CI

### DIFF
--- a/.github/workflows/windows-10-qt6.yml
+++ b/.github/workflows/windows-10-qt6.yml
@@ -29,7 +29,7 @@ env:
   MINGW_BITNESS: 64
   MINGW_CHOCOBASE: /c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64
   MINGW_INSTALLBASE: ${{ github.workspace }}/mingw64/
-  QT_VERSION: 6.0.2
+  QT_VERSION: 6.1.1
   QT_TOOLCHAIN: win64_mingw81
   QT_MODULES: qtbase qttools qttranslations qt5compat
   QT_INSTALLBASE: ${{ github.workspace }}/Qt/

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,7 @@ env:
   MINGW_BITNESS: 32
   MINGW_CHOCOBASE: /c/ProgramData/chocolatey/lib/mingw/tools/install/mingw32
   MINGW_INSTALLBASE: ${{ github.workspace }}/mingw32/
-  QT_VERSION: 5.15.1
+  QT_VERSION: 5.15.2
   QT_TOOLCHAIN: win32_mingw81
   QT_MODULES: qtbase qttools qttranslations
   QT_INSTALLBASE: ${{ github.workspace }}/Qt/

--- a/BambooTracker/gui/comment_edit_dialog.cpp
+++ b/BambooTracker/gui/comment_edit_dialog.cpp
@@ -31,7 +31,7 @@ CommentEditDialog::CommentEditDialog(QString comment, QWidget *parent) :
 	ui(new Ui::CommentEditDialog)
 {
 	ui->setupUi(this);
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 	ui->plainTextEdit->setPlainText(comment);
 }
 

--- a/BambooTracker/gui/configuration_dialog.cpp
+++ b/BambooTracker/gui/configuration_dialog.cpp
@@ -84,7 +84,7 @@ ConfigurationDialog::ConfigurationDialog(std::weak_ptr<Configuration> config, st
 {
 	ui->setupUi(this);
 
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 	QObject::connect(ui->buttonBox->button(QDialogButtonBox::Apply), &QPushButton::clicked,
 					 this, [&] {
 		on_ConfigurationDialog_accepted();

--- a/BambooTracker/gui/effect_list_dialog.cpp
+++ b/BambooTracker/gui/effect_list_dialog.cpp
@@ -34,7 +34,7 @@ EffectListDialog::EffectListDialog(QWidget *parent) :
 	ui(new Ui::EffectListDialog)
 {
 	ui->setupUi(this);
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
 	ui->tableWidget->setColumnWidth(0, 50);
 	ui->tableWidget->setColumnWidth(1, 100);

--- a/BambooTracker/gui/fm_envelope_set_edit_dialog.cpp
+++ b/BambooTracker/gui/fm_envelope_set_edit_dialog.cpp
@@ -34,7 +34,7 @@ FMEnvelopeSetEditDialog::FMEnvelopeSetEditDialog(std::vector<FMEnvelopeTextType>
 {
 	ui->setupUi(this);
 
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
 	for (size_t i = 0; i < set.size(); ++i) {
 		insertRow(static_cast<int>(i), set.at(i));

--- a/BambooTracker/gui/go_to_dialog.cpp
+++ b/BambooTracker/gui/go_to_dialog.cpp
@@ -36,7 +36,7 @@ GoToDialog::GoToDialog(std::weak_ptr<BambooTracker> bt, QWidget *parent) :
 {
 	ui->setupUi(this);
 
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
 
 	ui->orderSpinBox->setMaximum(bt.lock()->getOrderSize(song_) - 1);

--- a/BambooTracker/gui/groove_settings_dialog.cpp
+++ b/BambooTracker/gui/groove_settings_dialog.cpp
@@ -39,7 +39,7 @@ GrooveSettingsDialog::GrooveSettingsDialog(QWidget *parent) :
 {
 	ui->setupUi(this);
 
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 	ui->grooveListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 }
 

--- a/BambooTracker/gui/hide_tracks_dialog.cpp
+++ b/BambooTracker/gui/hide_tracks_dialog.cpp
@@ -36,7 +36,7 @@ HideTracksDialog::HideTracksDialog(const SongStyle& style, const std::vector<int
 {
 	ui->setupUi(this);
 
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
 	for (const auto& attrib : style.trackAttribs) {
 		auto item = new QListWidgetItem(gui_utils::getTrackName(style.type, attrib.source, attrib.channelInSource), ui->listWidget);

--- a/BambooTracker/gui/instrument_editor/grid_settings_dialog.cpp
+++ b/BambooTracker/gui/instrument_editor/grid_settings_dialog.cpp
@@ -32,7 +32,7 @@ GridSettingsDialog::GridSettingsDialog(int interval, QWidget *parent) :
 {
 	ui->setupUi(this);
 
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
 	ui->intrSpinBox->setValue(interval);
 }

--- a/BambooTracker/gui/instrument_editor/sample_length_dialog.cpp
+++ b/BambooTracker/gui/instrument_editor/sample_length_dialog.cpp
@@ -32,7 +32,7 @@ SampleLengthDialog::SampleLengthDialog(int len, QWidget *parent) :
 {
 	ui->setupUi(this);
 
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
 	ui->spinBox->setValue(len);
 }

--- a/BambooTracker/gui/instrument_selection_dialog.cpp
+++ b/BambooTracker/gui/instrument_selection_dialog.cpp
@@ -35,7 +35,7 @@ InstrumentSelectionDialog::InstrumentSelectionDialog(const AbstractBank &bank, c
 	: QDialog(parent), bank_(bank), config_(config), ui_(new Ui::InstrumentSelectionDialog)
 {
 	ui_->setupUi(this);
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 	ui_->label->setText(text);
 	setupContents();
 

--- a/BambooTracker/gui/keyboard_shortcut_list_dialog.cpp
+++ b/BambooTracker/gui/keyboard_shortcut_list_dialog.cpp
@@ -31,7 +31,7 @@ KeyboardShortcutListDialog::KeyboardShortcutListDialog(QWidget *parent) :
 	ui(new Ui::KeyboardShortcutListDialog)
 {
 	ui->setupUi(this);
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
 KeyboardShortcutListDialog::~KeyboardShortcutListDialog()

--- a/BambooTracker/gui/module_properties_dialog.cpp
+++ b/BambooTracker/gui/module_properties_dialog.cpp
@@ -44,7 +44,7 @@ ModulePropertiesDialog::ModulePropertiesDialog(std::weak_ptr<BambooTracker> core
 {
 	ui->setupUi(this);
 
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
 	int tickFreq = static_cast<int>(core.lock()->getModuleTickFrequency());
 	ui->customTickFreqSpinBox->setValue(tickFreq);

--- a/BambooTracker/gui/s98_export_settings_dialog.cpp
+++ b/BambooTracker/gui/s98_export_settings_dialog.cpp
@@ -33,7 +33,7 @@ S98ExportSettingsDialog::S98ExportSettingsDialog(QWidget *parent) :
 {
 	ui->setupUi(this);
 
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
 	for (QRadioButton *button : {
 		 ui->ym2608RadioButton, ui->ym2612RadioButton, ui->ym2203RadioButton, ui->noneFmRadioButton,

--- a/BambooTracker/gui/swap_tracks_dialog.cpp
+++ b/BambooTracker/gui/swap_tracks_dialog.cpp
@@ -35,7 +35,7 @@ SwapTracksDialog::SwapTracksDialog(const SongStyle& style, QWidget *parent) :
 {
 	ui->setupUi(this);
 
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
 	for (const auto& attrib : style.trackAttribs) {
 		QString text = gui_utils::getTrackName(style.type, attrib.source, attrib.channelInSource);

--- a/BambooTracker/gui/transpose_song_dialog.cpp
+++ b/BambooTracker/gui/transpose_song_dialog.cpp
@@ -33,7 +33,7 @@ TransposeSongDialog::TransposeSongDialog(QWidget *parent) :
 {
 	ui->setupUi(this);
 
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
 	for (int i = 0; i < 128; ++i) {
 		auto item = new QListWidgetItem(QString("%1").arg(i, 2, 16, QChar('0')).toUpper());

--- a/BambooTracker/gui/vgm_export_settings_dialog.cpp
+++ b/BambooTracker/gui/vgm_export_settings_dialog.cpp
@@ -34,7 +34,7 @@ VgmExportSettingsDialog::VgmExportSettingsDialog(QWidget *parent) :
 {
 	ui->setupUi(this);
 
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
 	for (QRadioButton *button : {
 		 ui->ym2608RadioButton, ui->ym2612RadioButton, ui->ym2203RadioButton, ui->noneFmRadioButton,

--- a/BambooTracker/gui/wave_export_settings_dialog.cpp
+++ b/BambooTracker/gui/wave_export_settings_dialog.cpp
@@ -32,7 +32,7 @@ WaveExportSettingsDialog::WaveExportSettingsDialog(QWidget *parent) :
 {
 	ui->setupUi(this);
 
-	setWindowFlags(windowFlags() ^ Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
 	ui->sampleRateComboBox->addItem("44100Hz", 44100);
 	ui->sampleRateComboBox->addItem("48000Hz", 48000);


### PR DESCRIPTION
- Qt6.0.2 -> Qt6.1.1
- Qt5.15.1 -> Qt5.15.2

Qt6 bump was tested on Discord. (download link: https://github.com/OPNA2608/BambooTracker/releases/download/v0.0.0/BambooTracker-v0.0.0-windows-10-64bit.zip)
Qt5 bump is untested, but it should only be bugfixes & therefore non-breaking.