### PR TITLE
Add compilation settings for SCCI and C86CTL

### DIFF
--- a/BambooTracker/BambooTracker.pro
+++ b/BambooTracker/BambooTracker.pro
@@ -46,7 +46,6 @@ QMAKE_CFLAGS_WARN_ON += $$CPP_WARNING_FLAGS
 QMAKE_CXXFLAGS_WARN_ON += $$CPP_WARNING_FLAGS
 
 SOURCES += \
-    chip/c86ctl/c86ctl_wrapper.cpp \
     chip/register_write_logger.cpp \
     command/instrument/swap_instruments_command.cpp \
     command/pattern/change_values_in_pattern_command.cpp \
@@ -216,11 +215,8 @@ SOURCES += \
 HEADERS += \
     bamboo_tracker_defs.hpp \
     chip/codec/ymb_codec.hpp \
-    chip/c86ctl/c86ctl.h \
-    chip/c86ctl/c86ctl_wrapper.hpp \
+    chip/real_chip_interface.hpp \
     chip/register_write_logger.hpp \
-    chip/scci/SCCIDefines.hpp \
-    chip/scci/scci.hpp \
     command/command_id.hpp \
     command/instrument/swap_instruments_command.hpp \
     command/pattern/change_values_in_pattern_command.hpp \
@@ -472,4 +468,20 @@ else {
   LIBS += -L$$OUT_PWD/../submodules/RtMidi
   CONFIG(debug, debug|release):LIBS += -lrtmidid
   else:CONFIG(release, debug|release):LIBS += -lrtmidi
+}
+
+win32:CONFIG += real_chip
+real_chip {
+  DEFINES += USE_REAL_CHIP
+
+  SOURCES += \
+    chip/c86ctl/c86ctl_wrapper.cpp \
+    chip/scci/scci_wrapper.cpp
+
+  HEADERS += \
+    chip/c86ctl/c86ctl.h \
+    chip/c86ctl/c86ctl_wrapper.hpp \
+    chip/scci/SCCIDefines.hpp \
+    chip/scci/scci.hpp \
+    chip/scci/scci_wrapper.hpp
 }

--- a/BambooTracker/bamboo_tracker.cpp
+++ b/BambooTracker/bamboo_tracker.cpp
@@ -1813,9 +1813,9 @@ void BambooTracker::useSCCI(scci::SoundInterfaceManager* manager)
 	opnaCtrl_->useSCCI(manager);
 }
 
-void BambooTracker::useC86CTL(C86ctlBase* base)
+void BambooTracker::setC86ctl(C86ctlGeneratorFunc *f)
 {
-	opnaCtrl_->useC86CTL(base);
+	opnaCtrl_->setC86ctl(f);
 }
 
 RealChipInterface BambooTracker::getRealChipinterface() const

--- a/BambooTracker/bamboo_tracker.cpp
+++ b/BambooTracker/bamboo_tracker.cpp
@@ -1808,20 +1808,20 @@ bool BambooTracker::exportToS98(io::BinaryContainer& container, int target, bool
 }
 
 /********** Real chip interface **********/
-void BambooTracker::useSCCI(scci::SoundInterfaceManager* manager)
+void BambooTracker::setScci(ScciGeneratorFunc* f)
 {
-	opnaCtrl_->useSCCI(manager);
+	opnaCtrl_->setScci(f);
 }
 
-void BambooTracker::setC86ctl(C86ctlGeneratorFunc *f)
+void BambooTracker::setC86ctl(C86ctlGeneratorFunc* f)
 {
 	opnaCtrl_->setC86ctl(f);
 }
 
 RealChipInterface BambooTracker::getRealChipinterface() const
 {
-	if (opnaCtrl_->isUsedSCCI()) return RealChipInterface::SCCI;
-	else if (opnaCtrl_->isUsedC86CTL()) return RealChipInterface::C86CTL;
+	if (opnaCtrl_->isUsedScci()) return RealChipInterface::SCCI;
+	else if (opnaCtrl_->isUsedC86ctl()) return RealChipInterface::C86CTL;
 	else return RealChipInterface::NONE;
 }
 

--- a/BambooTracker/bamboo_tracker.cpp
+++ b/BambooTracker/bamboo_tracker.cpp
@@ -1808,21 +1808,19 @@ bool BambooTracker::exportToS98(io::BinaryContainer& container, int target, bool
 }
 
 /********** Real chip interface **********/
-void BambooTracker::setScci(ScciGeneratorFunc* f)
+void BambooTracker::connectToRealChip(RealChipInterfaceType type, RealChipInterfaceGeneratorFunc* f)
 {
-	opnaCtrl_->setScci(f);
+	opnaCtrl_->connectToRealChip(type, f);
 }
 
-void BambooTracker::setC86ctl(C86ctlGeneratorFunc* f)
+RealChipInterfaceType BambooTracker::getRealChipInterfaceType() const
 {
-	opnaCtrl_->setC86ctl(f);
+	return opnaCtrl_->getRealChipInterfaceType();
 }
 
-RealChipInterface BambooTracker::getRealChipinterface() const
+bool BambooTracker::hasConnectedToRealChip() const
 {
-	if (opnaCtrl_->isUsedScci()) return RealChipInterface::SCCI;
-	else if (opnaCtrl_->isUsedC86ctl()) return RealChipInterface::C86CTL;
-	else return RealChipInterface::NONE;
+	return opnaCtrl_->hasConnectedToRealChip();
 }
 
 /********** Stream events **********/

--- a/BambooTracker/bamboo_tracker.hpp
+++ b/BambooTracker/bamboo_tracker.hpp
@@ -334,7 +334,7 @@ public:
 
 	// Real chip interface
 	void useSCCI(scci::SoundInterfaceManager* manager);
-	void useC86CTL(C86ctlBase* base);
+	void setC86ctl(C86ctlGeneratorFunc* f = nullptr);
 	RealChipInterface getRealChipinterface() const;
 
 	// Stream events

--- a/BambooTracker/bamboo_tracker.hpp
+++ b/BambooTracker/bamboo_tracker.hpp
@@ -37,8 +37,7 @@
 #include "instrument.hpp"
 #include "module.hpp"
 #include "command/command_manager.hpp"
-#include "chip/c86ctl/c86ctl_wrapper.hpp"
-#include "chip/scci/scci_wrapper.hpp"
+#include "chip/real_chip_interface.hpp"
 #include "io/binary_container.hpp"
 #include "io/export_io.hpp"
 #include "io/wav_container.hpp"
@@ -47,7 +46,6 @@
 
 class Configuration;
 enum class EffectDisplayControl;
-enum class RealChipInterface;
 class AbstractBank;
 class OPNAController;
 class PlaybackManager;
@@ -333,9 +331,9 @@ public:
 					 const io::S98Tag& tag, int rate, ExportCancellCallback checkFunc);
 
 	// Real chip interface
-	void setScci(ScciGeneratorFunc* f = nullptr);
-	void setC86ctl(C86ctlGeneratorFunc* f = nullptr);
-	RealChipInterface getRealChipinterface() const;
+	void connectToRealChip(RealChipInterfaceType type, RealChipInterfaceGeneratorFunc* f = nullptr);
+	RealChipInterfaceType getRealChipInterfaceType() const;
+	bool hasConnectedToRealChip() const;
 
 	// Stream events
 	/// 0<: Tick

--- a/BambooTracker/bamboo_tracker.hpp
+++ b/BambooTracker/bamboo_tracker.hpp
@@ -38,7 +38,7 @@
 #include "module.hpp"
 #include "command/command_manager.hpp"
 #include "chip/c86ctl/c86ctl_wrapper.hpp"
-#include "chip/scci/scci.hpp"
+#include "chip/scci/scci_wrapper.hpp"
 #include "io/binary_container.hpp"
 #include "io/export_io.hpp"
 #include "io/wav_container.hpp"
@@ -333,7 +333,7 @@ public:
 					 const io::S98Tag& tag, int rate, ExportCancellCallback checkFunc);
 
 	// Real chip interface
-	void useSCCI(scci::SoundInterfaceManager* manager);
+	void setScci(ScciGeneratorFunc* f = nullptr);
 	void setC86ctl(C86ctlGeneratorFunc* f = nullptr);
 	RealChipInterface getRealChipinterface() const;
 

--- a/BambooTracker/chip/c86ctl/c86ctl.h
+++ b/BambooTracker/chip/c86ctl/c86ctl.h
@@ -7,8 +7,6 @@
 	honet.kk(at)gmail.com
  */
 
-#ifdef _WIN32
-
 #ifndef _C86CTL_H
 #define _C86CTL_H
 
@@ -129,8 +127,6 @@ UCHAR WINAPI c86ctl_in( UINT addr );				/* DEPRECATED */
 #ifdef __cplusplus
 }
 }
-#endif
-
 #endif
 
 #endif

--- a/BambooTracker/chip/c86ctl/c86ctl_wrapper.cpp
+++ b/BambooTracker/chip/c86ctl/c86ctl_wrapper.cpp
@@ -1,126 +1,149 @@
+/*
+ * Copyright (C) 2020-2021 Rerrah
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 #include "c86ctl_wrapper.hpp"
+#include <cmath>
+
+#ifdef _WIN32
 #include "c86ctl.h"
+#endif
 
-C86ctlBase::C86ctlBase(void (*func)())
-	: base_(nullptr)
+C86ctl::C86ctl()
 {
 #ifdef _C86CTL_H
-	auto tmpFunc = reinterpret_cast<void*>(func);	// Avoid MSVC C4191
-	if (auto createInstance = reinterpret_cast<HRESULT(WINAPI*)(REFIID, void**)>(tmpFunc))
-		createInstance(c86ctl::IID_IRealChipBase, reinterpret_cast<void**>(&base_));
+	base_ = nullptr;
+	rc_ = nullptr;
+	gm_ = nullptr;
+#endif
+}
+
+C86ctl::~C86ctl()
+{
+#ifdef _C86CTL_H
+	if (gm_) gm_->Release();
+	if (rc_) rc_->Release();
+	if (base_) base_->Release();
+#endif
+}
+
+bool C86ctl::createInstance(C86ctlGeneratorFunc* f)
+{
+#ifdef _C86CTL_H
+	// Create instance
+	auto tmpFunc = f ? reinterpret_cast<void*>((*f)()) : nullptr;	// Avoid MSVC C4191
+	if (f) delete f;
+
+	if (auto createInstance = reinterpret_cast<HRESULT(WINAPI*)(REFIID, void**)>(tmpFunc)) {
+		c86ctl::IRealChipBase* base = nullptr;
+		createInstance(c86ctl::IID_IRealChipBase, reinterpret_cast<void**>(&base));
+		if (base_) {
+			base_->Release();
+			base_ = nullptr;
+			if (!base) return false;
+		}
+		base_ = base;
+		base_->initialize();
+		int nChip = base_->getNumberOfChip();
+		for (int i = 0; i < nChip; ++i) {
+			c86ctl::IRealChip2* rc = nullptr;
+			base_->getChipInterface(i, c86ctl::IID_IRealChip2, reinterpret_cast<void**>(&rc));
+			if (rc) {
+				if (rc_) rc_->Release();
+				rc_ = rc;
+				rc_->reset();
+
+				c86ctl::IGimic2* gm = nullptr;
+				if (rc_->QueryInterface(c86ctl::IID_IGimic2, reinterpret_cast<void**>(&gm)) == S_OK) {
+					c86ctl::ChipType type;
+					gm->getModuleType(&type);
+					if (type == c86ctl::CHIP_OPNA) {
+						if (gm_) gm_->Release();
+						gm_ = gm;
+						return true;
+					}
+					gm->Release();
+				}
+				rc_->Release();
+				rc_ = nullptr;
+			}
+		}
+	}
+	else {	// Clear interfaces
+		if (!base_) return false;
+		rc_->reset();
+		gm_->Release();
+		gm_ = nullptr;
+		rc_->Release();
+		rc_ = nullptr;
+	}
+
+	base_->deinitialize();
+	base_->Release();
+	base_ = nullptr;
 #else
-	(void)func;
+	if (f) delete f;
 #endif
+	return false;
 }
 
-bool C86ctlBase::isEmpty() const noexcept
-{
-	return (base_ == nullptr);
-}
-
-void C86ctlBase::initialize()
+bool C86ctl::isUsed() const
 {
 #ifdef _C86CTL_H
-	if (base_) base_->initialize();
-#endif
-}
-
-void C86ctlBase::deinitialize()
-{
-#ifdef _C86CTL_H
-	if (base_) base_->deinitialize();
-#endif
-}
-
-int C86ctlBase::getNumberOfChip()
-{
-#ifdef _C86CTL_H
-	if (base_) return base_->getNumberOfChip();
-#endif
-	return 0;
-}
-
-C86ctlRealChip* C86ctlBase::getChipInterface(int id)
-{
-	c86ctl::IRealChip2* rc = nullptr;
-#ifdef _C86CTL_H
-	if (base_) base_->getChipInterface(id, c86ctl::IID_IRealChip2, reinterpret_cast<void**>(&rc));
+	return (base_ != nullptr);
 #else
-	(void)id;
-#endif
-	return (rc ? new C86ctlRealChip(rc) : nullptr);
-}
-
-C86ctlRealChip::C86ctlRealChip(c86ctl::IRealChip2* rc)
-{
-#ifdef _C86CTL_H
-	rc_ = rc;
-#else
-	(void)rc;
+	return false;
 #endif
 }
 
-C86ctlRealChip::~C86ctlRealChip()
+void C86ctl::resetChip()
 {
 #ifdef _C86CTL_H
-	rc_->Release();
+	if (rc_) rc_->reset();
 #endif
 }
 
-void C86ctlRealChip::resetChip()
+void C86ctl::out(uint32_t addr, uint8_t data)
 {
 #ifdef _C86CTL_H
-	rc_->reset();
-#endif
-}
-
-void C86ctlRealChip::out(uint32_t addr, uint8_t data)
-{
-#ifdef _C86CTL_H
-	rc_->out(addr, data);
+	if (rc_) rc_->out(addr, data);
 #else
 	(void)addr;
 	(void)data;
 #endif
 }
 
-C86ctlGimic* C86ctlRealChip::queryInterface()
+void C86ctl::setSSGVolume(double dB)
 {
 #ifdef _C86CTL_H
-	c86ctl::IGimic2* gm = nullptr;
-	if (rc_->QueryInterface(c86ctl::IID_IGimic2, reinterpret_cast<void**>(&gm)) == S_OK) {
-		c86ctl::ChipType type;
-		gm->getModuleType(&type);
-		if (type == c86ctl::CHIP_OPNA) {
-			return new C86ctlGimic(gm);
-		}
-		gm->Release();
+	if (gm_) {
+		// NOTE: estimate SSG volume roughly
+		uint8_t vol = static_cast<uint8_t>(std::round((dB < -3.0) ? (2.5 * dB + 45.5)
+																  : (7. * dB + 59.)));
+		gm_->setSSGVolume(vol);
 	}
-#endif
-	return nullptr;
-}
-
-C86ctlGimic::C86ctlGimic(c86ctl::IGimic2* gm)
-{
-#ifdef _C86CTL_H
-	gm_ = gm;
 #else
-	(void)gm;
-#endif
-}
-
-C86ctlGimic::~C86ctlGimic()
-{
-#ifdef _C86CTL_H
-	gm_->Release();
-#endif
-}
-
-void C86ctlGimic::setSSGVolume(uint8_t vol)
-{
-#ifdef _C86CTL_H
-	gm_->setSSGVolume(vol);
-#else
-	(void)vol;
+	(void)dB;
 #endif
 }

--- a/BambooTracker/chip/c86ctl/c86ctl_wrapper.cpp
+++ b/BambooTracker/chip/c86ctl/c86ctl_wrapper.cpp
@@ -26,31 +26,22 @@
 #include "c86ctl_wrapper.hpp"
 #include <cmath>
 
-#ifdef _WIN32
 #include "c86ctl.h"
-#endif
 
-C86ctl::C86ctl()
-{
-#ifdef _C86CTL_H
-	base_ = nullptr;
-	rc_ = nullptr;
-	gm_ = nullptr;
-#endif
-}
+C86ctl::C86ctl() : base_(nullptr), rc_(nullptr), gm_(nullptr) {}
 
 C86ctl::~C86ctl()
 {
-#ifdef _C86CTL_H
 	if (gm_) gm_->Release();
 	if (rc_) rc_->Release();
-	if (base_) base_->Release();
-#endif
+	if (base_) {
+		base_->deinitialize();
+		base_->Release();
+	}
 }
 
-bool C86ctl::createInstance(C86ctlGeneratorFunc* f)
+bool C86ctl::createInstance(RealChipInterfaceGeneratorFunc* f)
 {
-#ifdef _C86CTL_H
 	// Create instance
 	auto tmpFunc = f ? reinterpret_cast<void*>((*f)()) : nullptr;	// Avoid MSVC C4191
 	if (f) delete f;
@@ -102,48 +93,30 @@ bool C86ctl::createInstance(C86ctlGeneratorFunc* f)
 	base_->deinitialize();
 	base_->Release();
 	base_ = nullptr;
-#else
-	if (f) delete f;
-#endif
 	return false;
 }
 
-bool C86ctl::isUsed() const
+bool C86ctl::hasConnected() const
 {
-#ifdef _C86CTL_H
 	return (base_ != nullptr);
-#else
-	return false;
-#endif
 }
 
-void C86ctl::resetChip()
+void C86ctl::reset()
 {
-#ifdef _C86CTL_H
 	if (rc_) rc_->reset();
-#endif
 }
 
-void C86ctl::out(uint32_t addr, uint8_t data)
+void C86ctl::setRegister(uint32_t addr, uint8_t data)
 {
-#ifdef _C86CTL_H
 	if (rc_) rc_->out(addr, data);
-#else
-	(void)addr;
-	(void)data;
-#endif
 }
 
 void C86ctl::setSSGVolume(double dB)
 {
-#ifdef _C86CTL_H
 	if (gm_) {
 		// NOTE: estimate SSG volume roughly
 		uint8_t vol = static_cast<uint8_t>(std::round((dB < -3.0) ? (2.5 * dB + 45.5)
 																  : (7. * dB + 59.)));
 		gm_->setSSGVolume(vol);
 	}
-#else
-	(void)dB;
-#endif
 }

--- a/BambooTracker/chip/c86ctl/c86ctl_wrapper.hpp
+++ b/BambooTracker/chip/c86ctl/c86ctl_wrapper.hpp
@@ -1,59 +1,68 @@
+/*
+ * Copyright (C) 2020-2021 Rerrah
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 #pragma once
 
 #include <cstdint>
 
+#ifdef _WIN32
 namespace c86ctl
 {
 struct IRealChipBase;
 struct IRealChip2;
 struct IGimic2;
 }
+#endif
 
-class C86ctlRealChip;
-class C86ctlGimic;
-
-class C86ctlBase
+struct C86ctlGeneratorFunc
 {
-public:
-	explicit C86ctlBase(void (*func)());
-	bool isEmpty() const noexcept;
-
-	void initialize();
-	void deinitialize();
-	int getNumberOfChip();
-	C86ctlRealChip* getChipInterface(int id);
+	using FuncPtr = void (*)();
+	C86ctlGeneratorFunc(FuncPtr fp) : fp_(fp) {}
+	FuncPtr operator()() const { return fp_; }
 
 private:
-	c86ctl::IRealChipBase* base_;
+	FuncPtr fp_;
 };
 
-class C86ctlRealChip
+class C86ctl
 {
 public:
-	explicit C86ctlRealChip(c86ctl::IRealChip2* rc);
-	~C86ctlRealChip();
+	C86ctl();
+	~C86ctl();
+	bool createInstance(C86ctlGeneratorFunc *f);
+	bool isUsed() const;
 
 	void resetChip();
 	void out(uint32_t addr, uint8_t data);
 
-	C86ctlGimic* queryInterface();
+	void setSSGVolume(double dB);
 
-#ifdef _WIN32
 private:
+#ifdef _WIN32
+	c86ctl::IRealChipBase* base_;
 	c86ctl::IRealChip2* rc_;
-#endif
-};
-
-class C86ctlGimic
-{
-public:
-	explicit C86ctlGimic(c86ctl::IGimic2* gm);
-	~C86ctlGimic();
-
-	void setSSGVolume(uint8_t vol);
-
-#ifdef _WIN32
-private:
 	c86ctl::IGimic2* gm_;
 #endif
 };

--- a/BambooTracker/chip/c86ctl/c86ctl_wrapper.hpp
+++ b/BambooTracker/chip/c86ctl/c86ctl_wrapper.hpp
@@ -26,43 +26,31 @@
 #pragma once
 
 #include <cstdint>
+#include "../real_chip_interface.hpp"
 
-#ifdef _WIN32
 namespace c86ctl
 {
 struct IRealChipBase;
 struct IRealChip2;
 struct IGimic2;
 }
-#endif
 
-struct C86ctlGeneratorFunc
-{
-	using FuncPtr = void (*)();
-	C86ctlGeneratorFunc(FuncPtr fp) : fp_(fp) {}
-	FuncPtr operator()() const { return fp_; }
-
-private:
-	FuncPtr fp_;
-};
-
-class C86ctl
+class C86ctl final : public SimpleRealChipInterface
 {
 public:
 	C86ctl();
-	~C86ctl();
-	bool createInstance(C86ctlGeneratorFunc *f);
-	bool isUsed() const;
+	~C86ctl() override;
+	bool createInstance(RealChipInterfaceGeneratorFunc* f) override;
+	RealChipInterfaceType getType() const override { return RealChipInterfaceType::C86CTL; }
+	bool hasConnected() const override;
 
-	void resetChip();
-	void out(uint32_t addr, uint8_t data);
+	void reset() override;
+	void setRegister(uint32_t addr, uint8_t data) override;
 
-	void setSSGVolume(double dB);
+	void setSSGVolume(double dB) override;
 
 private:
-#ifdef _WIN32
 	c86ctl::IRealChipBase* base_;
 	c86ctl::IRealChip2* rc_;
 	c86ctl::IGimic2* gm_;
-#endif
 };

--- a/BambooTracker/chip/opna.hpp
+++ b/BambooTracker/chip/opna.hpp
@@ -28,12 +28,7 @@
 #include "chip.hpp"
 #include <memory>
 #include "resampler.hpp"
-
-class Scci;
-class ScciGeneratorFunc;
-
-class C86ctl;
-class C86ctlGeneratorFunc;
+#include "real_chip_interface.hpp"
 
 namespace chip
 {
@@ -63,10 +58,10 @@ public:
 	void setVolumeSSG(double dB);
 	size_t getDRAMSize() const noexcept;
 	void mix(int16_t* stream, size_t nSamples) override;
-	void setScci(ScciGeneratorFunc* f);
-	bool isUsedScci() const noexcept;
-	void setC86ctl(C86ctlGeneratorFunc* f);
-	bool isUsedC86ctl() const noexcept;
+
+	void connectToRealChip(RealChipInterfaceType type, RealChipInterfaceGeneratorFunc* f);
+	RealChipInterfaceType getRealChipInterfaceType() const;
+	bool hasConnectedToRealChip() const;
 
 private:
 	static size_t count_;
@@ -74,7 +69,6 @@ private:
 	intf2608* intf_;
 	size_t dramSize_;
 
-	std::unique_ptr<Scci> scci_;
-	std::unique_ptr<C86ctl> c86ctl_;
+	std::unique_ptr<SimpleRealChipInterface> rcIntf_;
 };
 }

--- a/BambooTracker/chip/opna.hpp
+++ b/BambooTracker/chip/opna.hpp
@@ -35,9 +35,8 @@ class SoundInterfaceManager;
 class SoundChip;
 }
 
-class C86ctlBase;
-class C86ctlRealChip;
-class C86ctlGimic;
+class C86ctl;
+class C86ctlGeneratorFunc;
 
 namespace chip
 {
@@ -69,7 +68,7 @@ public:
 	void mix(int16_t* stream, size_t nSamples) override;
 	void useSCCI(scci::SoundInterfaceManager* manager);
 	bool isUsedSCCI() const noexcept;
-	void useC86CTL(C86ctlBase* base);
+	void setC86ctl(C86ctlGeneratorFunc *f);
 	bool isUsedC86CTL() const noexcept;
 
 private:
@@ -83,8 +82,6 @@ private:
 	scci::SoundChip* scciChip_;
 
 	// For C86CTL
-	std::unique_ptr<C86ctlBase> c86ctlBase_;
-	std::unique_ptr<C86ctlRealChip> c86ctlRC_;
-	std::unique_ptr<C86ctlGimic> c86ctlGm_;
+	std::unique_ptr<C86ctl> c86ctl_;
 };
 }

--- a/BambooTracker/chip/opna.hpp
+++ b/BambooTracker/chip/opna.hpp
@@ -29,11 +29,8 @@
 #include <memory>
 #include "resampler.hpp"
 
-namespace scci
-{
-class SoundInterfaceManager;
-class SoundChip;
-}
+class Scci;
+class ScciGeneratorFunc;
 
 class C86ctl;
 class C86ctlGeneratorFunc;
@@ -66,10 +63,10 @@ public:
 	void setVolumeSSG(double dB);
 	size_t getDRAMSize() const noexcept;
 	void mix(int16_t* stream, size_t nSamples) override;
-	void useSCCI(scci::SoundInterfaceManager* manager);
-	bool isUsedSCCI() const noexcept;
-	void setC86ctl(C86ctlGeneratorFunc *f);
-	bool isUsedC86CTL() const noexcept;
+	void setScci(ScciGeneratorFunc* f);
+	bool isUsedScci() const noexcept;
+	void setC86ctl(C86ctlGeneratorFunc* f);
+	bool isUsedC86ctl() const noexcept;
 
 private:
 	static size_t count_;
@@ -77,11 +74,7 @@ private:
 	intf2608* intf_;
 	size_t dramSize_;
 
-	// For SCCI
-	scci::SoundInterfaceManager* scciManager_;
-	scci::SoundChip* scciChip_;
-
-	// For C86CTL
+	std::unique_ptr<Scci> scci_;
 	std::unique_ptr<C86ctl> c86ctl_;
 };
 }

--- a/BambooTracker/chip/scci/scci_wrapper.cpp
+++ b/BambooTracker/chip/scci/scci_wrapper.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2021 Rerrah
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "scci_wrapper.hpp"
+
+#ifdef _WIN32
+#include "scci.hpp"
+#include "SCCIDefines.hpp"
+#endif
+
+Scci::Scci()
+{
+#ifdef _WIN32
+	scciManager_ = nullptr;
+	scciChip_ = nullptr;
+#endif
+}
+
+Scci::~Scci()
+{
+#ifdef _WIN32
+	if (scciChip_) scciManager_->releaseSoundChip(scciChip_);
+	if (scciManager_) scciManager_->releaseInstance();
+#endif
+}
+
+bool Scci::createInstance(ScciGeneratorFunc* f)
+{
+#ifdef _WIN32
+	auto getManager = f ? reinterpret_cast<scci::SCCIFUNC>((*f)()) : nullptr;
+	if (f) delete f;
+	auto man = getManager ? getManager() : nullptr;
+	if (man) {
+		scciManager_ = man;
+		scciManager_->initializeInstance();
+		scciManager_->reset();
+		scciChip_ = scciManager_->getSoundChip(scci::SC_TYPE_YM2608, scci::SC_CLOCK_7987200);
+		if (!scciChip_) {
+			scciManager_->releaseInstance();
+			scciManager_ = nullptr;
+			return false;
+		}
+		return true;
+	}
+	else {
+		if (!scciChip_) return false;
+		scciManager_->releaseSoundChip(scciChip_);
+		scciChip_ = nullptr;
+
+		scciManager_->releaseInstance();
+		scciManager_ = nullptr;
+		return false;
+	}
+#else
+	if (f) delete f;
+	return false;
+#endif
+}
+
+bool Scci::isUsed() const
+{
+#ifdef _WIN32
+	return (scciManager_ != nullptr);
+#else
+	return false;
+#endif
+}
+
+void Scci::initialize()
+{
+#ifdef _WIN32
+	if (scciChip_) scciChip_->init();
+#endif
+}
+
+void Scci::setRegister(uint32_t dAddr, uint32_t dData)
+{
+#ifdef _WIN32
+	if (scciChip_) scciChip_->setRegister(dAddr, dData);
+#else
+	(void)dAddr;
+	(void)dData;
+#endif
+}

--- a/BambooTracker/chip/scci/scci_wrapper.hpp
+++ b/BambooTracker/chip/scci/scci_wrapper.hpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2021 Rerrah
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#ifdef _WIN32
+namespace scci
+{
+class SoundInterfaceManager;
+class SoundChip;
+}
+#endif
+
+struct ScciGeneratorFunc
+{
+	using FuncPtr = void (*)();
+	ScciGeneratorFunc(FuncPtr fp) : fp_(fp) {}
+	FuncPtr operator()() const { return fp_; }
+
+private:
+	FuncPtr fp_;
+};
+
+class Scci
+{
+public:
+	Scci();
+	~Scci();
+	bool createInstance(ScciGeneratorFunc *f);
+	bool isUsed() const;
+
+	void initialize();
+	void setRegister(uint32_t dAddr, uint32_t dData);
+
+private:
+#ifdef _WIN32
+	scci::SoundInterfaceManager* scciManager_;
+	scci::SoundChip* scciChip_;
+#endif
+};

--- a/BambooTracker/chip/scci/scci_wrapper.hpp
+++ b/BambooTracker/chip/scci/scci_wrapper.hpp
@@ -26,39 +26,27 @@
 #pragma once
 
 #include <cstdint>
+#include "../real_chip_interface.hpp"
 
-#ifdef _WIN32
 namespace scci
 {
 class SoundInterfaceManager;
 class SoundChip;
 }
-#endif
 
-struct ScciGeneratorFunc
-{
-	using FuncPtr = void (*)();
-	ScciGeneratorFunc(FuncPtr fp) : fp_(fp) {}
-	FuncPtr operator()() const { return fp_; }
-
-private:
-	FuncPtr fp_;
-};
-
-class Scci
+class Scci final : public SimpleRealChipInterface
 {
 public:
 	Scci();
-	~Scci();
-	bool createInstance(ScciGeneratorFunc *f);
-	bool isUsed() const;
+	~Scci() override;
+	bool createInstance(RealChipInterfaceGeneratorFunc* f) override;
+	RealChipInterfaceType getType() const override { return RealChipInterfaceType::SCCI; }
+	bool hasConnected() const override;
 
-	void initialize();
-	void setRegister(uint32_t dAddr, uint32_t dData);
+	void reset() override;
+	void setRegister(uint32_t addr, uint8_t data) override;
 
 private:
-#ifdef _WIN32
-	scci::SoundInterfaceManager* scciManager_;
-	scci::SoundChip* scciChip_;
-#endif
+	scci::SoundInterfaceManager* man_;
+	scci::SoundChip* chip_;
 };

--- a/BambooTracker/configuration.cpp
+++ b/BambooTracker/configuration.cpp
@@ -25,6 +25,7 @@
 
 #include "configuration.hpp"
 #include "jamming.hpp"
+#include "chip/real_chip_interface.hpp"
 
 namespace
 {
@@ -283,7 +284,7 @@ Configuration::Configuration()
 	// Sound //
 	sndAPI_ = u8"";
 	sndDevice_ = u8"";
-	realChip_ = RealChipInterface::NONE;
+	realChip_ = RealChipInterfaceType::NONE;
 	emulator_ = 1;
 	sampleRate_ = 44100;
 	bufferLength_ = 40;

--- a/BambooTracker/configuration.hpp
+++ b/BambooTracker/configuration.hpp
@@ -33,6 +33,7 @@
 #include "enum_hash.hpp"
 
 enum class JamKey : int;
+enum class RealChipInterfaceType : int;
 
 enum class FMEnvelopeTextType : int
 {
@@ -47,13 +48,6 @@ struct FMEnvelopeText
 {
 	std::string name;
 	std::vector<FMEnvelopeTextType> texts;
-};
-
-enum class RealChipInterface : int
-{
-	NONE = 0,
-	SCCI = 1,
-	C86CTL = 2
 };
 
 enum class NoteNotationSystem : int
@@ -289,8 +283,8 @@ public:
 	std::string getSoundAPI() const { return sndAPI_; }
 	void setSoundDevice(const std::string& device) { sndDevice_ = device; }
 	std::string getSoundDevice() const { return sndDevice_; }
-	void setRealChipInterface(RealChipInterface type) { realChip_ = type; }
-	RealChipInterface getRealChipInterface() const { return realChip_; }
+	void setRealChipInterface(RealChipInterfaceType type) { realChip_ = type; }
+	RealChipInterfaceType getRealChipInterface() const { return realChip_; }
 	void setEmulator(int emulator) { emulator_ = emulator; }
 	int getEmulator() const { return emulator_; }
 	void setSampleRate(uint32_t rate) { sampleRate_ = rate; }
@@ -299,7 +293,7 @@ public:
 	size_t getBufferLength() const { return bufferLength_; }
 private:
 	std::string sndAPI_, sndDevice_;
-	RealChipInterface realChip_;
+	RealChipInterfaceType realChip_;
 	int emulator_;
 	uint32_t sampleRate_;
 	size_t bufferLength_;

--- a/BambooTracker/gui/configuration_dialog.cpp
+++ b/BambooTracker/gui/configuration_dialog.cpp
@@ -312,14 +312,16 @@ ConfigurationDialog::ConfigurationDialog(std::weak_ptr<Configuration> config, st
 	}
 	on_audioApiComboBox_currentIndexChanged(ui->audioApiComboBox->currentText());
 
-	ui->realChipComboBox->addItem(tr("None"), static_cast<int>(RealChipInterface::NONE));
-	ui->realChipComboBox->addItem("SCCI", static_cast<int>(RealChipInterface::SCCI));
-	ui->realChipComboBox->addItem("C86CTL", static_cast<int>(RealChipInterface::C86CTL));
+	ui->realChipComboBox->addItem(tr("None"), static_cast<int>(RealChipInterfaceType::NONE));
+#ifdef USE_REAL_CHIP
+	ui->realChipComboBox->addItem("SCCI", static_cast<int>(RealChipInterfaceType::SCCI));
+	ui->realChipComboBox->addItem("C86CTL", static_cast<int>(RealChipInterfaceType::C86CTL));
+#endif
 	switch (configLocked->getRealChipInterface()) {
 	default:	// Fall through
-	case RealChipInterface::NONE:	ui->realChipComboBox->setCurrentIndex(0);	break;
-	case RealChipInterface::SCCI:	ui->realChipComboBox->setCurrentIndex(1);	break;
-	case RealChipInterface::C86CTL:	ui->realChipComboBox->setCurrentIndex(2);	break;
+	case RealChipInterfaceType::NONE:	ui->realChipComboBox->setCurrentIndex(0);	break;
+	case RealChipInterfaceType::SCCI:	ui->realChipComboBox->setCurrentIndex(1);	break;
+	case RealChipInterfaceType::C86CTL:	ui->realChipComboBox->setCurrentIndex(2);	break;
 	}
 
 	{
@@ -465,7 +467,7 @@ void ConfigurationDialog::on_ConfigurationDialog_accepted()
 	// Sound //
 	configLocked->setSoundDevice(ui->audioDeviceComboBox->currentText().toUtf8().toStdString());
 	configLocked->setSoundAPI(ui->audioApiComboBox->currentText().toUtf8().toStdString());
-	configLocked->setRealChipInterface(static_cast<RealChipInterface>(
+	configLocked->setRealChipInterface(static_cast<RealChipInterfaceType>(
 										   ui->realChipComboBox->currentData(Qt::UserRole).toInt()));
 	configLocked->setMidiEnabled(ui->midiInputGroupBox->isChecked());
 	configLocked->setMidiAPI(ui->midiApiComboBox->currentText().toUtf8().toStdString());

--- a/BambooTracker/gui/configuration_handler.cpp
+++ b/BambooTracker/gui/configuration_handler.cpp
@@ -432,7 +432,7 @@ bool loadConfiguration(std::weak_ptr<Configuration> config)
 		settings.beginGroup("Sound");
 		configLocked->setSoundAPI(settings.value("soundAPI", QString::fromStdString(configLocked->getSoundAPI())).toString().toUtf8().toStdString());
 		configLocked->setSoundDevice(settings.value("soundDevice", QString::fromStdString(configLocked->getSoundDevice())).toString().toUtf8().toStdString());
-		configLocked->setRealChipInterface(static_cast<RealChipInterface>(
+		configLocked->setRealChipInterface(static_cast<RealChipInterfaceType>(
 											   settings.value("realChipInterface", static_cast<int>(configLocked->getRealChipInterface())).toInt()));
 		configLocked->setEmulator(settings.value("emulator", configLocked->getEmulator()).toInt());
 		QVariant sampleRateWorkaround;

--- a/BambooTracker/gui/mainwindow.cpp
+++ b/BambooTracker/gui/mainwindow.cpp
@@ -109,8 +109,8 @@ MainWindow::MainWindow(std::weak_ptr<Configuration> config, QString filePath, bo
 	bt_(std::make_shared<BambooTracker>(config)),
 	comStack_(std::make_shared<QUndoStack>(this)),
 	fileHistory_(std::make_shared<FileHistory>()),
-	scciDll_(std::make_unique<QLibrary>("scci")),
-	c86ctlDll_(std::make_unique<QLibrary>("c86ctl")),
+	scciDll_(std::make_shared<QLibrary>("scci")),
+	c86ctlDll_(std::make_shared<QLibrary>("c86ctl")),
 	instForms_(std::make_shared<InstrumentFormManager>()),
 	renamingInstItem_(nullptr),
 	renamingInstEdit_(nullptr),
@@ -751,12 +751,8 @@ MainWindow::MainWindow(std::weak_ptr<Configuration> config, QString filePath, bo
 			showStreamFailedDialog(streamErr);
 		}
 	}
-	RealChipInterface intf = config.lock()->getRealChipInterface();
-	if (intf == RealChipInterface::NONE) {
-		bt_->setScci();
-		bt_->setC86ctl();
-	}
-	else {
+	RealChipInterfaceType intf = config.lock()->getRealChipInterface();
+	if (intf != RealChipInterfaceType::NONE) {
 		tickTimerForRealChip_ = std::make_unique<PreciseTimer>();
 		tickTimerForRealChip_->setInterval(1000000 / bt_->getModuleTickFrequency());
 		tickEventMethod_ = metaObject()->indexOfSlot("onNewTickSignaledRealChip()");
@@ -2331,11 +2327,10 @@ void MainWindow::changeConfiguration()
 {
 	// Real chip interface
 	bool streamState = false;
-	RealChipInterface intf = config_.lock()->getRealChipInterface();
-	if (intf == RealChipInterface::NONE) {
+	RealChipInterfaceType intf = config_.lock()->getRealChipInterface();
+	if (intf == RealChipInterfaceType::NONE) {
 		tickTimerForRealChip_.reset();
-		bt_->setScci();
-		bt_->setC86ctl();
+		bt_->connectToRealChip(RealChipInterfaceType::NONE);
 		QString streamErr;
 		streamState = stream_->initialize(
 						  config_.lock()->getSampleRate(),
@@ -2395,9 +2390,9 @@ void MainWindow::changeConfiguration()
 	update();
 }
 
-void MainWindow::setRealChipInterface(RealChipInterface intf)
+void MainWindow::setRealChipInterface(RealChipInterfaceType intf)
 {
-	if (intf == bt_->getRealChipinterface()) return;
+	if (intf == bt_->getRealChipInterfaceType()) return;
 
 	if (isWindowModified()
 			&& QMessageBox::warning(this, tr("Warning"),
@@ -2406,31 +2401,22 @@ void MainWindow::setRealChipInterface(RealChipInterface intf)
 		on_actionSave_As_triggered();
 	}
 
-	switch (intf) {
-	case RealChipInterface::SCCI:
-		bt_->setC86ctl();
-		scciDll_->load();
-		if (scciDll_->isLoaded()) {
+	struct Pair
+	{
+		std::weak_ptr<QLibrary> lib;
+		const char* symbol;
+	};
+	static std::unordered_map<RealChipInterfaceType, Pair> RCI_DIC = {
+		{ RealChipInterfaceType::SCCI, { scciDll_, "getSoundInterfaceManager" } },
+		{ RealChipInterfaceType::C86CTL, { c86ctlDll_, "CreateInstance" } }
+	};
 
-			bt_->setScci(new ScciGeneratorFunc(scciDll_->resolve("getSoundInterfaceManager")));
-		}
-		else {
-			bt_->setScci();
-		}
-		break;
-	case RealChipInterface::C86CTL:
-		bt_->setScci();
-		c86ctlDll_->load();
-		if (c86ctlDll_->isLoaded()) {
-			bt_->setC86ctl(new C86ctlGeneratorFunc(c86ctlDll_->resolve("CreateInstance")));
-		}
-		else {
-			bt_->setC86ctl();
-		}
-		break;
-	default:
-		break;
-	}
+	auto& dll = RCI_DIC.at(intf).lib;
+	dll.lock()->load();
+	if (dll.lock()->isLoaded())
+		bt_->connectToRealChip(intf, new RealChipInterfaceGeneratorFunc(dll.lock()->resolve(RCI_DIC[intf].symbol)));
+	else
+		bt_->connectToRealChip(RealChipInterfaceType::NONE);
 
 	bt_->assignSampleADPCMRawSamples();	// Mutex register
 	instForms_->onInstrumentADPCMSampleMemoryUpdated();

--- a/BambooTracker/gui/mainwindow.cpp
+++ b/BambooTracker/gui/mainwindow.cpp
@@ -754,7 +754,7 @@ MainWindow::MainWindow(std::weak_ptr<Configuration> config, QString filePath, bo
 	RealChipInterface intf = config.lock()->getRealChipInterface();
 	if (intf == RealChipInterface::NONE) {
 		bt_->useSCCI(nullptr);
-		bt_->useC86CTL(nullptr);
+		bt_->setC86ctl();
 	}
 	else {
 		tickTimerForRealChip_ = std::make_unique<PreciseTimer>();
@@ -2335,7 +2335,7 @@ void MainWindow::changeConfiguration()
 	if (intf == RealChipInterface::NONE) {
 		tickTimerForRealChip_.reset();
 		bt_->useSCCI(nullptr);
-		bt_->useC86CTL(nullptr);
+		bt_->setC86ctl();
 		QString streamErr;
 		streamState = stream_->initialize(
 						  config_.lock()->getSampleRate(),
@@ -2408,7 +2408,7 @@ void MainWindow::setRealChipInterface(RealChipInterface intf)
 
 	switch (intf) {
 	case RealChipInterface::SCCI:
-		bt_->useC86CTL(nullptr);
+		bt_->setC86ctl();
 		scciDll_->load();
 		if (scciDll_->isLoaded()) {
 			auto getManager = reinterpret_cast<scci::SCCIFUNC>(
@@ -2423,10 +2423,10 @@ void MainWindow::setRealChipInterface(RealChipInterface intf)
 		bt_->useSCCI(nullptr);
 		c86ctlDll_->load();
 		if (c86ctlDll_->isLoaded()) {
-			bt_->useC86CTL(new C86ctlBase(c86ctlDll_->resolve("CreateInstance")));
+			bt_->setC86ctl(new C86ctlGeneratorFunc(c86ctlDll_->resolve("CreateInstance")));
 		}
 		else {
-			bt_->useC86CTL(nullptr);
+			bt_->setC86ctl();
 		}
 		break;
 	default:

--- a/BambooTracker/gui/mainwindow.hpp
+++ b/BambooTracker/gui/mainwindow.hpp
@@ -106,7 +106,7 @@ private:
 	std::shared_ptr<QUndoStack> comStack_;
 	std::shared_ptr<FileHistory> fileHistory_;
 
-	std::unique_ptr<QLibrary> scciDll_, c86ctlDll_;
+	std::shared_ptr<QLibrary> scciDll_, c86ctlDll_;
 
 	// Instrument list
 	std::shared_ptr<InstrumentFormManager> instForms_;
@@ -155,7 +155,7 @@ private:
 
 	// Configuration change
 	void changeConfiguration();
-	void setRealChipInterface(RealChipInterface intf);
+	void setRealChipInterface(RealChipInterfaceType intf);
 	void setMidiConfiguration();
 	void updateFonts();
 

--- a/BambooTracker/opna_controller.cpp
+++ b/BambooTracker/opna_controller.cpp
@@ -168,9 +168,9 @@ bool OPNAController::isUsedSCCI() const
 	return opna_->isUsedSCCI();
 }
 
-void OPNAController::useC86CTL(C86ctlBase* base)
+void OPNAController::setC86ctl(C86ctlGeneratorFunc* f)
 {
-	opna_->useC86CTL(base);
+	opna_->setC86ctl(f);
 }
 
 bool OPNAController::isUsedC86CTL() const

--- a/BambooTracker/opna_controller.cpp
+++ b/BambooTracker/opna_controller.cpp
@@ -158,24 +158,19 @@ void OPNAController::updateRegisterStates()
 }
 
 /********** Real chip interface **********/
-void OPNAController::setScci(ScciGeneratorFunc* f)
+void OPNAController::connectToRealChip(RealChipInterfaceType type, RealChipInterfaceGeneratorFunc* f)
 {
-	opna_->setScci(f);
+	opna_->connectToRealChip(type, f);
 }
 
-bool OPNAController::isUsedScci() const
+RealChipInterfaceType OPNAController::getRealChipInterfaceType() const
 {
-	return opna_->isUsedScci();
+	return opna_->getRealChipInterfaceType();
 }
 
-void OPNAController::setC86ctl(C86ctlGeneratorFunc* f)
+bool OPNAController::hasConnectedToRealChip() const
 {
-	opna_->setC86ctl(f);
-}
-
-bool OPNAController::isUsedC86ctl() const
-{
-	return opna_->isUsedC86ctl();
+	return opna_->hasConnectedToRealChip();
 }
 
 /********** Stream samples **********/

--- a/BambooTracker/opna_controller.cpp
+++ b/BambooTracker/opna_controller.cpp
@@ -158,14 +158,14 @@ void OPNAController::updateRegisterStates()
 }
 
 /********** Real chip interface **********/
-void OPNAController::useSCCI(scci::SoundInterfaceManager* manager)
+void OPNAController::setScci(ScciGeneratorFunc* f)
 {
-	opna_->useSCCI(manager);
+	opna_->setScci(f);
 }
 
-bool OPNAController::isUsedSCCI() const
+bool OPNAController::isUsedScci() const
 {
-	return opna_->isUsedSCCI();
+	return opna_->isUsedScci();
 }
 
 void OPNAController::setC86ctl(C86ctlGeneratorFunc* f)
@@ -173,9 +173,9 @@ void OPNAController::setC86ctl(C86ctlGeneratorFunc* f)
 	opna_->setC86ctl(f);
 }
 
-bool OPNAController::isUsedC86CTL() const
+bool OPNAController::isUsedC86ctl() const
 {
-	return opna_->isUsedC86CTL();
+	return opna_->isUsedC86ctl();
 }
 
 /********** Stream samples **********/

--- a/BambooTracker/opna_controller.hpp
+++ b/BambooTracker/opna_controller.hpp
@@ -58,10 +58,9 @@ public:
 	void updateRegisterStates();
 
 	// Real chip interface
-	void setScci(ScciGeneratorFunc* f);
-	bool isUsedScci() const;
-	void setC86ctl(C86ctlGeneratorFunc* f);
-	bool isUsedC86ctl() const;
+	void connectToRealChip(RealChipInterfaceType type, RealChipInterfaceGeneratorFunc* f);
+	RealChipInterfaceType getRealChipInterfaceType() const;
+	bool hasConnectedToRealChip() const;
 
 	// Stream samples
 	void getStreamSamples(int16_t* container, size_t nSamples);

--- a/BambooTracker/opna_controller.hpp
+++ b/BambooTracker/opna_controller.hpp
@@ -58,10 +58,10 @@ public:
 	void updateRegisterStates();
 
 	// Real chip interface
-	void useSCCI(scci::SoundInterfaceManager* manager);
-	bool isUsedSCCI() const;
+	void setScci(ScciGeneratorFunc* f);
+	bool isUsedScci() const;
 	void setC86ctl(C86ctlGeneratorFunc* f);
-	bool isUsedC86CTL() const;
+	bool isUsedC86ctl() const;
 
 	// Stream samples
 	void getStreamSamples(int16_t* container, size_t nSamples);

--- a/BambooTracker/opna_controller.hpp
+++ b/BambooTracker/opna_controller.hpp
@@ -60,7 +60,7 @@ public:
 	// Real chip interface
 	void useSCCI(scci::SoundInterfaceManager* manager);
 	bool isUsedSCCI() const;
-	void useC86CTL(C86ctlBase* base);
+	void setC86ctl(C86ctlGeneratorFunc* f);
 	bool isUsedC86CTL() const;
 
 	// Stream samples

--- a/README.md
+++ b/README.md
@@ -299,10 +299,12 @@ Qmake options (flags/switches):
   - use_jack: Compile with explicit support for JACK 1/2<sup>13</sup>.
   - system_rtaudio: Skips RtAudio compilation and links against the system's RtAudio installation instead.
   - system_rtmidi: Skips RtMidi compilation and links against the system's RtMidi installation instead.
+  - real_chip: Compile with support for SCCI and C86CTL interfaces to a real OPNA chip<sup>4</sup>. (Default on Windows)
 
 <sup>1</sup>: Only works on Linux and BSD.  
 <sup>2</sup>: Shipped & auto-detected(?) on FreeBSD but possibly not functional in RtAudio.  
-<sup>3</sup>: API technically supported on Windows but unlikely to compile in Rt library.
+<sup>3</sup>: API technically supported on Windows but unlikely to compile in Rt library.  
+<sup>4</sup>: Builds code that doesn't use an OSI-certified license. Only supported on Windows.
 
 Example:
 ```bash

--- a/README_ja.md
+++ b/README_ja.md
@@ -300,10 +300,12 @@ Qmakeのオプション (フラグ/スイッチ):
   - use_jack: 明示的にJACK 1/2<sup>13</sup>に対応してコンパイルします。
   - system_rtaudio: RtAudioのコンパイルをスキップし、代わりにシステムのインストールされているRtAudioにリンクします。
   - system_rtmidi: RtMidiのコンパイルをスキップし、代わりにシステムのインストールされているRtMidiにリンクします。
+  - real_chip: SCCIとC86CTLに対応したコンパイルを行います<sup>4</sup>。(Windowsではデフォルトで有効)
 
 <sup>1</sup>: LinuxとBSDでのみ動作します。  
 <sup>2</sup>: FreeBSDでは自動検出されます(?)が、RtAudioでは機能しない可能性があります。  
-<sup>3</sup>: APIは技術的にはWindowsでサポートされていますが、Rtライブラリではコンパイルが困難なようです。
+<sup>3</sup>: APIは技術的にはWindowsでサポートされていますが、Rtライブラリではコンパイルが困難なようです。  
+<sup>4</sup>: OSI認証ライセンスを使用しないコードをビルドします。これらはWindowsにのみ対応しています。
 
 例:
 ```bash


### PR DESCRIPTION
Close #357.

Setting `CONFIG += real_chip`, SCCI and C86CTL sources and their wrapper classes are added to the build source list.
I have rewritten BambooTracker.pro to add this setting on Windows, and remove it on macOS and Linux by default.
If you want to use these interfaces on the latter platforms (which is unlikely), change the options in qmake.