### PR TITLE
Fix the incorrect size of the rectangular paste for orders

### DIFF
--- a/BambooTracker/bamboo_tracker.cpp
+++ b/BambooTracker/bamboo_tracker.cpp
@@ -2513,8 +2513,8 @@ void BambooTracker::deleteOrder(int songNum, int orderNum)
 bool BambooTracker::pasteOrderCells(int songNum, int beginTrack, int beginOrder, const Vector2d<int>& cells)
 {
 	// Clip given cells to fit the size of pasted area.
-	std::size_t w = std::min(cells.rowSize(), songStyle_.trackAttribs.size() - static_cast<size_t>(beginTrack));
-	std::size_t h = std::min(cells.columnSize(), getOrderSize(songNum) - static_cast<size_t>(beginOrder));
+	std::size_t w = std::min(cells.columnSize(), songStyle_.trackAttribs.size() - static_cast<size_t>(beginTrack));
+	std::size_t h = std::min(cells.rowSize(), getOrderSize(songNum) - static_cast<size_t>(beginOrder));
 	if (w == 0 || h == 0) return false;
 
 	auto clipped = cells.clip(0, 0, h, w);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## Unreleased
 
-### v0.6.5 (2025-03-08)
+### Fixed
+
+- [#537] - Fix the incorrect size of the rectangular paste for orders ([#536]; thanks [@agargara])
+
+[@agargara]: https://github.com/agargara
+
+[#536]: https://github.com/BambooTracker/BambooTracker/issues/536
+[#537]: https://github.com/BambooTracker/BambooTracker/pull/517
+
+## v0.6.5 (2025-03-08)
 
 ### Added
 


### PR DESCRIPTION
Fixed #536. The vertical and horizontal dimensions of the copied order rectangle area were swapped.