### PR TITLE
Allow copying in Jam Mode, allow order copying when opening context menu outside of selection

### DIFF
--- a/BambooTracker/gui/mainwindow.cpp
+++ b/BambooTracker/gui/mainwindow.cpp
@@ -2905,9 +2905,11 @@ void MainWindow::updateMenuByPatternSelection(bool isSelected)
 {
 	isSelectedPattern_ = isSelected;
 
+	// Copying isn't really editing, so not dependent on mode.
+	ui->actionCopy->setEnabled(isSelected);
+
 	if (bt_->isJamMode()) {
 		// Edit
-		ui->actionCopy->setEnabled(false);
 		ui->actionCut->setEnabled(false);
 		// Pattern
 		ui->actionInterpolate->setEnabled(false);
@@ -2918,7 +2920,6 @@ void MainWindow::updateMenuByPatternSelection(bool isSelected)
 	}
 	else {
 		// Edit
-		ui->actionCopy->setEnabled(isSelected);
 		ui->actionCut->setEnabled(isEditedPattern_ ? isSelected : false);
 		// Pattern
 		bool enabled = (isEditedPattern_ && isEditedPattern_) ? isSelected : false;

--- a/BambooTracker/gui/order_list_editor/order_list_panel.cpp
+++ b/BambooTracker/gui/order_list_editor/order_list_panel.cpp
@@ -70,6 +70,7 @@ OrderListPanel::OrderListPanel(QWidget *parent)
 	  isIgnoreToPattern_(false),
 	  entryCnt_(0),
 	  selectAllState_(-1),
+	  allowCopy_(false),
 	  viewedRowCnt_(1),
 	  viewedRowsHeight_(0),
 	  viewedRowOffset_(0),
@@ -126,6 +127,8 @@ OrderListPanel::OrderListPanel(QWidget *parent)
 					QPoint(calculateColumnsWidthWithRowNum(leftTrackVisIdx_, curPos_.trackVisIdx), curRowY_ - 8));
 	});
 	onShortcutUpdated();
+
+	QObject::connect(this, &OrderListPanel::selected, this, &OrderListPanel::updateAllowCopy);
 }
 
 void OrderListPanel::setCore(std::shared_ptr<BambooTracker> core)
@@ -1145,12 +1148,13 @@ void OrderListPanel::showContextMenu(const OrderPosition& pos, const QPoint& poi
 	copy->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_C));
 	paste->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_V));
 
+	copy->setEnabled(allowCopy_);
+
 	bool notCurHov = (pos.row < 0 || pos.trackVisIdx < 0);
 	if (notCurHov) {
 		remove->setEnabled(false);
 		moveUp->setEnabled(false);
 		moveDown->setEnabled(false);
-		copy->setEnabled(false);
 		paste->setEnabled(false);
 	}
 	if (!bt_->canAddNewOrder(curSongNum_)) {
@@ -1158,7 +1162,6 @@ void OrderListPanel::showContextMenu(const OrderPosition& pos, const QPoint& poi
 		duplicate->setEnabled(false);
 		moveUp->setEnabled(false);
 		moveDown->setEnabled(false);
-		copy->setEnabled(false);
 		paste->setEnabled(false);
 	}
 	QString clipText = QApplication::clipboard()->text();
@@ -1170,7 +1173,6 @@ void OrderListPanel::showContextMenu(const OrderPosition& pos, const QPoint& poi
 	}
 	if (selRightBelowPos_.row < 0
 			|| !isSelectedCell(pos.trackVisIdx, pos.row)) {
-		copy->setEnabled(false);
 		// Turn off when no pattern is hilighted
 		if (notCurHov) clonep->setEnabled(false);
 	}
@@ -1682,4 +1684,8 @@ void OrderListPanel::leaveEvent(QEvent*)
 {
 	// Clear mouse hover selection
 	hovPos_ = { -1, -1 };
+}
+
+void OrderListPanel::updateAllowCopy(bool allowCopy) {
+	allowCopy_ = allowCopy;
 }

--- a/BambooTracker/gui/order_list_editor/order_list_panel.hpp
+++ b/BambooTracker/gui/order_list_editor/order_list_panel.hpp
@@ -172,6 +172,7 @@ private:
 	int entryCnt_;
 
 	int selectAllState_;
+	bool allowCopy_;
 
 	int viewedRowCnt_;
 	int viewedRegionHeight_;
@@ -225,6 +226,9 @@ private:
 	bool isSelectedCell(int trackIdx, int row);
 
 	void showContextMenu(const OrderPosition& pos, const QPoint& point);
+
+private slots:
+	void updateAllowCopy(bool allowCopy);
 };
 
 #endif // ORDER_LIST_PANEL_HPP

--- a/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
+++ b/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
@@ -93,6 +93,7 @@ PatternEditorPanel::PatternEditorPanel(QWidget *parent)
 	  isPressedMinus_(false),
 	  entryCnt_(0),
 	  selectAllState_(-1),
+	  allowCopy_(false),
 	  isMuteElse_(false),
 	  hl1Cnt_(4),
 	  hl2Cnt_(16),
@@ -271,6 +272,8 @@ PatternEditorPanel::PatternEditorPanel(QWidget *parent)
 	midiKeyEventMethod_ = metaObject()->indexOfSlot("midiKeyEvent(uchar,uchar,uchar)");
 	Q_ASSERT(midiKeyEventMethod_ != -1);
 	MidiInterface::getInstance().installInputHandler(&midiThreadReceivedEvent, this);
+
+	QObject::connect(this, &PatternEditorPanel::selected, this, &PatternEditorPanel::updateAllowCopy);
 }
 
 PatternEditorPanel::~PatternEditorPanel()
@@ -2301,8 +2304,9 @@ void PatternEditorPanel::showPatternContextMenu(const PatternPosition& pos, cons
 	exeff->setShortcut(gui_utils::strToKeySeq(shortcuts.at(Configuration::ShortcutAction::ExpandEffect)));
 	sheff->setShortcut(gui_utils::strToKeySeq(shortcuts.at(Configuration::ShortcutAction::ShrinkEffect)));
 
+	copy->setEnabled(allowCopy_);
+
 	if (bt_->isJamMode() || pos.order < 0 || pos.trackVisIdx < 0) {
-		copy->setEnabled(false);
 		cut->setEnabled(false);
 		paste->setEnabled(false);
 		pasteMix->setEnabled(false);
@@ -3314,4 +3318,8 @@ void PatternEditorPanel::midiKeyEvent(uchar status, uchar key, uchar velocity)
 			setStepKeyOn(Note(static_cast<int>(key) - 12));
 		}
 	}
+}
+
+void PatternEditorPanel::updateAllowCopy(bool allowCopy) {
+	allowCopy_ = allowCopy;
 }

--- a/BambooTracker/gui/pattern_editor/pattern_editor_panel.hpp
+++ b/BambooTracker/gui/pattern_editor/pattern_editor_panel.hpp
@@ -147,6 +147,7 @@ private:
 	static void midiThreadReceivedEvent(double delay, const uint8_t *msg, size_t len, void *userData);
 private slots:
 	void midiKeyEvent(uchar status, uchar key, uchar velocity);
+	void updateAllowCopy(bool allowCopy);
 
 private:
 	QPixmap completePixmap_, backPixmap_, textPixmap_, forePixmap_, headerPixmap_;
@@ -193,6 +194,7 @@ private:
 	int entryCnt_;
 
 	int selectAllState_;
+	bool allowCopy_;
 	bool isMuteElse_;
 
 	int hl1Cnt_, hl2Cnt_;


### PR DESCRIPTION
<img width="752" height="373" alt="image" src="https://github.com/user-attachments/assets/11fac59f-cceb-42c4-a046-ccb4e1176620" />

Confusion about this happened to at least one user.

Selection is fully enabled in Jam Mode, so I suppose there should be no reason to disallow copying, since it doesn't affect the module.

The context menu is created ad-hoc, while the `Edit` menu at the top updates based on signals. I figured saving the last `selected` signal's value to determine if copying should be allowed in the created context menu made the most sense.

---

<img width="429" height="374" alt="image" src="https://github.com/user-attachments/assets/bb30e469-1891-419a-96bb-b58c468810e1" />

No mentions of this yet, but it's a similar restriction.

There should be no real reason to require the user to right-click exactly into the order list selection for the copy option to be available. We have a signal indicating when the selection in the element changes, so just reuse that.